### PR TITLE
Change all usages of 'gets' to 'fgets' + 'strtok' to remove the newline characters.

### DIFF
--- a/src/colorer/viewer/ConsoleTools.cpp
+++ b/src/colorer/viewer/ConsoleTools.cpp
@@ -200,10 +200,12 @@ void ConsoleTools::RETest(){
   re = new CRegExp();
   do{
     printf("\nregexp:");
-    gets(text);
+    fgets(text, sizeof(text), stdin);
+    strtok(text, "\r\n");
     if (!re->setRE(&DString(text))) continue;
     printf("exprn:");
-    gets(text);
+    fgets(text, sizeof(text), stdin);
+    strtok(text, "\r\n");
     res = re->parse(&DString(text), &match);
     printf("%s\nmatch:  ",res?"ok":"error");
     for(int i = 0; i < match.cMatch; i++){

--- a/src/colorer/viewer/TextLinesStore.cpp
+++ b/src/colorer/viewer/TextLinesStore.cpp
@@ -30,7 +30,8 @@ void TextLinesStore::loadFile(const String *fileName, const String *inputEncodin
 
   if (fileName == null){
     char line[256];
-    while(gets(line) != null){
+    while(fgets(line, sizeof(line), stdin) != null){
+      strtok(line, "\r\n");
       lines.addElement(new SString(line));
       if (tab2spaces) replaceTabs(lines.size()-1);
     }


### PR DESCRIPTION
'gets(...)' is deprecated and causes compilation errors with newer compilers (tried with VS 2015).

