### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,11 +176,11 @@ set_target_properties(colorer_lib PROPERTIES
     )
 
 target_link_libraries(colorer_lib
-    PUBLIC ICU::uc ICU::data XercesC::XercesC spdlog::spdlog
+    PUBLIC ICU::uc ICU::data XercesC::XercesC spdlog::spdlog stdc++fs
     )
 
 if(COLORER_FEATURE_JARINPUTSOURCE)
-  target_link_libraries(colorer_lib PUBLIC minizip::minizip)
+  target_link_libraries(colorer_lib PUBLIC minizip::minizip stdc++fs)
 endif()
 
 


### PR DESCRIPTION
Link to libstdc++ for linux.
This appears to be required for gcc < 9
Else linker errors "like undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'"
Might be CentOS only or GCC <9 only so require a version check