### PR TITLE
Include cstdint for compatibility with GCC 15

### DIFF
--- a/src/colorer/strings/legacy/UnicodeString.h
+++ b/src/colorer/strings/legacy/UnicodeString.h
@@ -2,6 +2,7 @@
 #define COLORER_UNICODESTRING_H
 
 #include <colorer/strings/legacy/CommonString.h>
+#include <cstdint>
 #include <memory>
 
 class CString;


### PR DESCRIPTION
cstdint needs to be included explicitly since GCC 15.
https://gcc.gnu.org/gcc-15/porting_to.html

```
[  1%] Building CXX object src/CMakeFiles/colorer_lib.dir/colorer/common/Exception.cpp.o
cd /Colorer-library/build/src && /usr/sbin/c++  -I/Colorer-library/src -I/Colorer-library/build/src -isystem /usr/include/libxml2 -O3 -DNDEBUG -std=gnu++17 -Werror -fpermissive -Wall -Wextra -Wpedantic -Wsign-promo -Wnon-virtual-dtor -MD -MT src/CMakeFiles/colorer_lib.dir/colorer/common/Exception.cpp.o -MF CMakeFiles/colorer_lib.dir/colorer/common/Exception.cpp.o.d -o CMakeFiles/colorer_lib.dir/colorer/common/Exception.cpp.o -c /Colorer-library/src/colorer/common/Exception.cpp
In file included from /Colorer-library/src/colorer/strings/legacy/common_legacy.h:4,
                 from /Colorer-library/src/colorer/strings/legacy/strings.h:4,
                 from /Colorer-library/src/colorer/Common.h:9,
                 from /Colorer-library/src/colorer/Exception.h:6,
                 from /Colorer-library/src/colorer/common/Exception.cpp:1:
/Colorer-library/src/colorer/strings/legacy/UnicodeString.h:20:23: error: 'uint16_t' does not name a type
   20 |   UnicodeString(const uint16_t* str);
      |                       ^~~~~~~~
```
