### PR TITLE
Fix parser crashes on transient null lines and temporary string lifetime

### DIFF
--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -521,8 +521,13 @@ bool TextParser::Impl::colorize(CRegExp* root_end_re, bool lowContentPriority)
       clearLine = current_parse_line;
       str = lineSource->getLine(current_parse_line);
       if (str == nullptr) {
-        throw Exception("null String passed into the parser: " +
-                        UStr::to_unistr(current_parse_line));
+        // LineSource can return null if the line is not available (e.g. editor shutdown).
+        // Stop parsing gracefully instead of throwing across threads.
+        str = nullptr;
+        clearLine = -1;
+        endLine = current_parse_line;
+        stackLevel--;
+        return true;
       }
       regionHandler->clearLine(current_parse_line, str);
     }

--- a/src/colorer/strings/legacy/UnicodeString.cpp
+++ b/src/colorer/strings/legacy/UnicodeString.cpp
@@ -3,6 +3,7 @@
 #include <colorer/strings/legacy/Encodings.h>
 #include <colorer/strings/legacy/UnicodeString.h>
 #include <cstdlib>
+#include <string>
 #include "colorer/Exception.h"
 
 UnicodeString operator+(const UnicodeString& s1, const UnicodeString& s2)
@@ -90,7 +91,8 @@ UnicodeString::UnicodeString(const UnicodeString& cstring, int32_t s, int32_t l)
 
 UnicodeString::UnicodeString(int no)
 {
-  CString dtext = CString(std::to_string(no).c_str());
+  const std::string number_text = std::to_string(no);
+  CString dtext = CString(number_text.c_str());
   construct(&dtext, 0, npos);
 }
 


### PR DESCRIPTION
This PR addresses a series of ASan-reported crashes in the colorer parser and related string handling when testing quick colored popups creation and destruction in scope of elfmz/far2l#3248

Findings

- UnicodeString::UnicodeString(int) built a CString from std::to_string(no).c_str() where the std::string temporary died before CString was consumed, causing a stack-use-after-scope read.
- TextParser::Impl::colorize() threw an exception when LineSource::getLine() returned null, which propagated across threads and left the UI in a bad state.
- After the null-return fix, the parser could still reuse a stale str pointer on a later pass (because clearLine blocked a fresh getLine()), leading to a null/invalid deref at str->length().

Changes

- Make the std::to_string() result live long enough in UnicodeString::UnicodeString(int) by storing it in a local std::string before constructing CString.
- In TextParser::Impl::colorize(), treat null lines as a graceful stop condition instead of throwing; return cleanly.
- Reset str and clearLine when getLine() returns null to avoid reusing stale pointers on subsequent passes.

Notes

- These changes target shutdown/transient editor states where lines are unavailable.
- No behavior change for normal parsing flow; only defensive handling for unavailable lines and invalid lifetimes.

Testing

- Reproduced crash with ASan before; retested after changes and the issue no longer reproduced.