### PR TITLE
Performance changes from far2l

### DIFF
--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -1,4 +1,7 @@
 #include "colorer/cregexp/cregexp.h"
+#include <array>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 StackElem* CRegExp::RegExpStack {nullptr};
@@ -66,6 +69,8 @@ void CRegExp::init()
   positionMoves = false;
   error = EError::EERROR;
   firstNode = nullptr;
+  firstCharMask = {};
+  firstCharMaskUseful = false;
   cMatch = 0;
   global_pattern = nullptr;
 #ifdef COLORERMODE
@@ -206,6 +211,134 @@ void CRegExp::optimize()
     }
     break;
   }
+
+  const auto firstChars = analyzeFirstChars(tree_root);
+  firstCharMask = firstChars.mask;
+  firstCharMaskUseful = !firstChars.nullable &&
+    (firstCharMask[0] != ~uint64_t(0) || firstCharMask[1] != ~uint64_t(0));
+}
+
+void CRegExp::addFirstChar(FirstChars& result, wchar ch) const
+{
+  const auto value = static_cast<uint32_t>(ch);
+  if (value >= 128) return;
+  result.mask[value >> 6] |= uint64_t(1) << (value & 63);
+  if (ignoreCase && value >= 'A' && value <= 'Z') {
+    const auto lower = value + ('a' - 'A');
+    result.mask[lower >> 6] |= uint64_t(1) << (lower & 63);
+  }
+  else if (ignoreCase && value >= 'a' && value <= 'z') {
+    const auto upper = value - ('a' - 'A');
+    result.mask[upper >> 6] |= uint64_t(1) << (upper & 63);
+  }
+}
+
+CRegExp::FirstChars CRegExp::firstCharsForNode(const SRegInfo* re) const
+{
+  FirstChars result;
+  if (!re) {
+    result.nullable = true;
+    return result;
+  }
+  switch (re->op) {
+    case EOps::ReSymb:
+      addFirstChar(result, re->un.symbol);
+      break;
+    case EOps::ReWord:
+      if (re->un.word->length()) addFirstChar(result, (*re->un.word)[0]);
+      else result.nullable = true;
+      break;
+    case EOps::ReEnum:
+    case EOps::ReNEnum:
+      for (uint32_t ch = 0; ch < 128; ch++) {
+        if (re->un.charclass->contains(static_cast<wchar>(ch)) == (re->op == EOps::ReEnum)) {
+          result.mask[ch >> 6] |= uint64_t(1) << (ch & 63);
+        }
+      }
+      break;
+    case EOps::ReMetaSymb:
+      switch (re->un.metaSymbol) {
+        case EMetaSymbols::ReAnyChr:
+          result.mask = {~uint64_t(0), ~uint64_t(0)};
+          if (!singleLine) {
+            for (const uint32_t ch : {0x0Au, 0x0Bu, 0x0Cu, 0x0Du})
+              result.mask[ch >> 6] &= ~(uint64_t(1) << (ch & 63));
+          }
+          break;
+        case EMetaSymbols::ReDigit:
+        case EMetaSymbols::ReNDigit:
+        case EMetaSymbols::ReWordSymb:
+        case EMetaSymbols::ReNWordSymb:
+        case EMetaSymbols::ReWSpace:
+        case EMetaSymbols::ReNWSpace:
+        case EMetaSymbols::ReUCase:
+        case EMetaSymbols::ReNUCase:
+          for (uint32_t ch = 0; ch < 128; ch++) {
+            bool matchesChar = false;
+            switch (re->un.metaSymbol) {
+              case EMetaSymbols::ReDigit: matchesChar = Character::isDigit(ch); break;
+              case EMetaSymbols::ReNDigit: matchesChar = !Character::isDigit(ch); break;
+              case EMetaSymbols::ReWordSymb: matchesChar = Character::isLetterOrDigitOrUnderscore(ch); break;
+              case EMetaSymbols::ReNWordSymb: matchesChar = !Character::isLetterOrDigitOrUnderscore(ch); break;
+              case EMetaSymbols::ReWSpace: matchesChar = Character::isWhitespace(ch); break;
+              case EMetaSymbols::ReNWSpace: matchesChar = !Character::isWhitespace(ch); break;
+              case EMetaSymbols::ReUCase: matchesChar = Character::isUpperCase(ch); break;
+              case EMetaSymbols::ReNUCase: matchesChar = Character::isLowerCase(ch); break;
+              default: break;
+            }
+            if (matchesChar) result.mask[ch >> 6] |= uint64_t(1) << (ch & 63);
+          }
+          break;
+        default:
+          result.nullable = true;
+          break;
+      }
+      break;
+    case EOps::ReBrackets:
+    case EOps::ReNamedBrackets:
+      result = analyzeFirstChars(re->un.param);
+      break;
+    case EOps::ReOr: {
+      result = analyzeFirstChars(re->un.param);
+      const auto right = analyzeFirstChars(re->next);
+      result.mask[0] |= right.mask[0];
+      result.mask[1] |= right.mask[1];
+      result.nullable = result.nullable || right.nullable;
+      break;
+    }
+    case EOps::ReRangeN:
+    case EOps::ReRangeNM:
+    case EOps::ReNGRangeN:
+    case EOps::ReNGRangeNM:
+      result = analyzeFirstChars(re->un.param);
+      result.nullable = re->s == 0 || result.nullable;
+      break;
+    case EOps::ReAhead:
+    case EOps::ReNAhead:
+    case EOps::ReBehind:
+    case EOps::ReNBehind:
+    case EOps::ReEmpty:
+      result.nullable = true;
+      break;
+    default:
+      result.mask = {~uint64_t(0), ~uint64_t(0)};
+      break;
+  }
+  return result;
+}
+
+CRegExp::FirstChars CRegExp::analyzeFirstChars(const SRegInfo* re) const
+{
+  FirstChars result;
+  result.nullable = true;
+  for (auto* node = re; node && result.nullable; node = node->next) {
+    const auto current = firstCharsForNode(node);
+    result.mask[0] |= current.mask[0];
+    result.mask[1] |= current.mask[1];
+    result.nullable = current.nullable;
+    if (node->op == EOps::ReOr) break;
+  }
+  return result;
 }
 
 EError CRegExp::setStructs(SRegInfo*& re, const UnicodeString& expr, int& retPos)
@@ -1371,6 +1504,10 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
 
 bool CRegExp::canStartWith(wchar ch) const
 {
+  const auto value = static_cast<uint32_t>(ch);
+  if (firstCharMaskUseful && value < 128) {
+    return (firstCharMask[value >> 6] & (uint64_t(1) << (value & 63))) != 0;
+  }
   if (!firstNode) {
     return true;
   }
@@ -1448,6 +1585,11 @@ inline bool CRegExp::parseRE(int pos)
 
   int toParse = pos;
 
+  if (!positionMoves && firstCharMaskUseful) {
+    if (toParse >= end) return false;
+    const auto ch = static_cast<uint32_t>((*global_pattern)[toParse]);
+    if (ch < 128 && !(firstCharMask[ch >> 6] & (uint64_t(1) << (ch & 63)))) return false;
+  }
   if (!positionMoves && firstNode && !quickCheck(toParse))
     return false;
 

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -716,10 +716,6 @@ bool CRegExp::isWordBoundary(int toParse)
   const bool before = (toParse > 0 && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse - 1]));
   return before != after;
 }
-bool CRegExp::isNWordBoundary(int toParse)
-{
-  return !isWordBoundary(toParse);
-}
 
 bool CRegExp::checkMetaSymbol(EMetaSymbols symb, int& toParse)
 {
@@ -727,88 +723,89 @@ bool CRegExp::checkMetaSymbol(EMetaSymbols symb, int& toParse)
 
   switch (symb) {
     case EMetaSymbols::ReAnyChr:
-      if (toParse >= end)
-        return false;
-      if (!singleLine && isLineBreak(pattern[toParse]))
+      if (toParse >= end || (!singleLine && isLineBreak(pattern[toParse])))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReSoL:
-      if (multiLine) {
-        bool ok = false;
-        if (toParse && isLineBreak(pattern[toParse - 1]))
-          ok = true;
-        return (toParse == 0 || ok);
-      }
-      return (toParse == 0);
+        return toParse == 0 || (multiLine && isLineBreak(pattern[toParse - 1]));
+
     case EMetaSymbols::ReEoL:
-      if (multiLine) {
-        bool ok = false;  // ???check
-        if (toParse && toParse < end && isLineBreak(pattern[toParse - 1]))
-          ok = true;
-        return (toParse == end || ok);
-      }
-      return (end == toParse);
+      return toParse == end || (multiLine && toParse && toParse < end && isLineBreak(pattern[toParse - 1]));
+
     case EMetaSymbols::ReDigit:
       if (toParse >= end || !Character::isDigit(pattern[toParse]))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReNDigit:
       if (toParse >= end || Character::isDigit(pattern[toParse]))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReWordSymb:
       if (toParse >= end || !Character::isLetterOrDigitOrUnderscore(pattern[toParse]))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReNWordSymb:
       if (toParse >= end || Character::isLetterOrDigitOrUnderscore(pattern[toParse]))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReWSpace:
       if (toParse >= end || !Character::isWhitespace(pattern[toParse]))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReNWSpace:
       if (toParse >= end || Character::isWhitespace(pattern[toParse]))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReUCase:
       if (toParse >= end || !Character::isUpperCase(pattern[toParse]))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReNUCase:
       if (toParse >= end || !Character::isLowerCase(pattern[toParse]))
         return false;
       toParse++;
       return true;
+
     case EMetaSymbols::ReWBound:
       return isWordBoundary(toParse);
+
     case EMetaSymbols::ReNWBound:
-      return isNWordBoundary(toParse);
+      return !isWordBoundary(toParse);
+
     case EMetaSymbols::RePreNW:
-      if (toParse >= end)
-        return true;
-      return toParse == 0 || !Character::isLetter(pattern[toParse - 1]);
+      return toParse == 0 || toParse >= end || !Character::isLetter(pattern[toParse - 1]);
+
 #ifdef COLORERMODE
     case EMetaSymbols::ReSoScheme:
       return (schemeStart == toParse);
+
     case EMetaSymbols::ReStart:
       matches->s[0] = toParse;
       startChange = true;
       return true;
+
     case EMetaSymbols::ReEnd:
       matches->e[0] = toParse;
       endChange = true;
       return true;
 #endif
+
     default:
       return false;
   }

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -1370,6 +1370,11 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
   }
 }
 
+bool CRegExp::canStartWith(wchar ch) const
+{
+  return firstChar == BAD_WCHAR || matchChars(ch, firstChar);
+}
+
 inline bool CRegExp::quickCheck(int toParse)
 {
   if (firstChar != BAD_WCHAR) {

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -74,6 +74,12 @@ CRegExp::~CRegExp()
 #endif
 }
 
+bool CRegExp::matchChars(wchar one, wchar another) const
+{
+  return one == another ||
+    (ignoreCase && Character::toLowerCase(one) == Character::toLowerCase(another));
+}
+
 EError CRegExp::setRELow(const UnicodeString& expr)
 {
   auto len = expr.length();
@@ -890,15 +896,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
               check_stack(false, &re, &prev, &toParse, &leftenter, &action);
               continue;
             }
-            if (ignoreCase) {
-              if (Character::toLowerCase(pattern[toParse]) != Character::toLowerCase(re->un.symbol) &&
-                  Character::toUpperCase(pattern[toParse]) != Character::toUpperCase(re->un.symbol))
-              {
-                check_stack(false, &re, &prev, &toParse, &leftenter, &action);
-                continue;
-              }
-            }
-            else if (pattern[toParse] != re->un.symbol) {
+            if (!matchChars(pattern[toParse], re->un.symbol)) {
               check_stack(false, &re, &prev, &toParse, &leftenter, &action);
               continue;
             }
@@ -1347,15 +1345,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
 inline bool CRegExp::quickCheck(int toParse)
 {
   if (firstChar != BAD_WCHAR) {
-    if (toParse >= end)
-      return false;
-    if (ignoreCase) {
-      if (Character::toLowerCase((*global_pattern)[toParse]) != Character::toLowerCase(firstChar))
-        return false;
-    }
-    else if ((*global_pattern)[toParse] != firstChar)
-      return false;
-    return true;
+    return toParse < end && matchChars((*global_pattern)[toParse], firstChar);
   }
   if (firstMetaChar != EMetaSymbols::ReBadMeta)
     switch (firstMetaChar) {

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -22,8 +22,8 @@ void SMatches::topnseSanitize(int cur)
 {
     while (topnse < cur) {
       ++topnse;
-      s[topnse] = -1;
-      e[topnse] = -1;
+      ns[topnse] = -1;
+      ne[topnse] = -1;
     }
 }
 #endif
@@ -1430,6 +1430,10 @@ inline bool CRegExp::parseRE(int pos)
   do {
     // stack=null;
     if (lowParse(tree_root, nullptr, toParse)) {
+      matches->topseSanitize(cMatch - 1);
+#ifndef NAMED_MATCHES_IN_HASH
+      matches->topnseSanitize(cnMatch - 1);
+#endif
       return true;
     }
     if (!positionMoves)

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -705,15 +705,16 @@ EError CRegExp::setStructs(SRegInfo*& re, const UnicodeString& expr, int& retPos
 // parsing
 ////////////////////////////////////////////////////////////////////////////
 
+static bool isLineBreak(wchar_t c)
+{
+   return c == 0x0A || c == 0x0B || c == 0x0C || c == 0x0D || c == 0x85 || c == 0x2028 || c == 0x2029;
+}
+
 bool CRegExp::isWordBoundary(int toParse)
 {
-  int before = 0;
-  int after = 0;
-  if (toParse < end && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse]))
-    after = 1;
-  if (toParse > 0 && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse - 1]))
-    before = 1;
-  return before + after == 1;
+  const bool after = (toParse < end && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse]));
+  const bool before = (toParse > 0 && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse - 1]));
+  return before != after;
 }
 bool CRegExp::isNWordBoundary(int toParse)
 {
@@ -728,20 +729,14 @@ bool CRegExp::checkMetaSymbol(EMetaSymbols symb, int& toParse)
     case EMetaSymbols::ReAnyChr:
       if (toParse >= end)
         return false;
-      if (!singleLine &&
-          (pattern[toParse] == 0x0A || pattern[toParse] == 0x0B || pattern[toParse] == 0x0C ||
-           pattern[toParse] == 0x0D || pattern[toParse] == 0x85 || pattern[toParse] == 0x2028 ||
-           pattern[toParse] == 0x2029))
+      if (!singleLine && isLineBreak(pattern[toParse]))
         return false;
       toParse++;
       return true;
     case EMetaSymbols::ReSoL:
       if (multiLine) {
         bool ok = false;
-        if (toParse &&
-            (pattern[toParse - 1] == 0x0A || pattern[toParse - 1] == 0x0B || pattern[toParse - 1] == 0x0C ||
-             pattern[toParse - 1] == 0x0D || pattern[toParse - 1] == 0x85 || pattern[toParse - 1] == 0x2028 ||
-             pattern[toParse - 1] == 0x2029))
+        if (toParse && isLineBreak(pattern[toParse - 1]))
           ok = true;
         return (toParse == 0 || ok);
       }
@@ -749,10 +744,7 @@ bool CRegExp::checkMetaSymbol(EMetaSymbols symb, int& toParse)
     case EMetaSymbols::ReEoL:
       if (multiLine) {
         bool ok = false;  // ???check
-        if (toParse && toParse < end &&
-            (pattern[toParse - 1] == 0x0A || pattern[toParse - 1] == 0x0B || pattern[toParse - 1] == 0x0C ||
-             pattern[toParse - 1] == 0x0D || pattern[toParse - 1] == 0x85 || pattern[toParse - 1] == 0x2028 ||
-             pattern[toParse - 1] == 0x2029))
+        if (toParse && toParse < end && isLineBreak(pattern[toParse - 1]))
           ok = true;
         return (toParse == end || ok);
       }
@@ -1397,8 +1389,7 @@ bool CRegExp::canStartWith(wchar ch) const
     case EOps::ReMetaSymb:
       switch (firstNode->un.metaSymbol) {
         case EMetaSymbols::ReAnyChr:
-          return singleLine || (ch != 0x0A && ch != 0x0B && ch != 0x0C && ch != 0x0D &&
-                                ch != 0x85 && ch != 0x2028 && ch != 0x2029);
+          return singleLine || !isLineBreak(ch);
         case EMetaSymbols::ReDigit:
           return Character::isDigit(ch);
         case EMetaSymbols::ReNDigit:

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -3,8 +3,32 @@
 
 StackElem* CRegExp::RegExpStack {nullptr};
 int CRegExp::RegExpStack_Size {0};
+
+
 /////////////////////////////////////////////////////////////////////////////
-//
+
+
+void SMatches::topseSanitize(int cur)
+{
+    while (topse < cur) {
+      ++topse;
+      s[topse] = -1;
+      e[topse] = -1;
+    }
+}
+
+#if !defined NAMED_MATCHES_IN_HASH
+void SMatches::topnseSanitize(int cur)
+{
+    while (topnse < cur) {
+      ++topnse;
+      s[topnse] = -1;
+      e[topnse] = -1;
+    }
+}
+#endif
+
+
 SRegInfo::SRegInfo()
 {
   un.param = nullptr;
@@ -872,6 +896,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
             if (re->param0 == -1)
               break;
             if (re->op == EOps::ReBrackets) {
+              matches->topseSanitize(re->param0);
               if (re->param0 || !startChange)
                 matches->s[re->param0] = re->s;
               if (re->param0 || !endChange)
@@ -881,6 +906,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
             }
             else {
 #ifndef NAMED_MATCHES_IN_HASH
+              matches->topnseSanitize(re->param0);
               matches->ns[re->param0] = re->s;
               matches->ne[re->param0] = toParse;
               if (matches->ne[re->param0] < matches->ns[re->param0])
@@ -1055,6 +1081,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
               check_stack(false, &re, &prev, &toParse, &leftenter, &action);
               continue;
             }
+            matches->topnseSanitize(sv);
             if (matches->ns[sv] == -1 || matches->ne[sv] == -1) {
               check_stack(false, &re, &prev, &toParse, &leftenter, &action);
               continue;
@@ -1102,6 +1129,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
               check_stack(false, &re, &prev, &toParse, &leftenter, &action);
               continue;
             }
+            matches->topseSanitize(sv);
             if (matches->s[sv] == -1 || matches->e[sv] == -1) {
               check_stack(false, &re, &prev, &toParse, &leftenter, &action);
               continue;
@@ -1394,17 +1422,16 @@ inline bool CRegExp::parseRE(int pos)
   if (!positionMoves && (firstChar != BAD_WCHAR || firstMetaChar != EMetaSymbols::ReBadMeta) && !quickCheck(toParse))
     return false;
 
-  int i;
-  for (i = 0; i < cMatch; i++) matches->s[i] = matches->e[i] = -1;
+  matches->reset();
   matches->cMatch = cMatch;
 #ifndef NAMED_MATCHES_IN_HASH
-  for (i = 0; i < cnMatch; i++) matches->ns[i] = matches->ne[i] = -1;
   matches->cnMatch = cnMatch;
 #endif
   do {
     // stack=null;
-    if (lowParse(tree_root, nullptr, toParse))
+    if (lowParse(tree_root, nullptr, toParse)) {
       return true;
+    }
     if (!positionMoves)
       return false;
     toParse = ++pos;

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -65,7 +65,7 @@ void CRegExp::init()
   tree_root = nullptr;
   positionMoves = false;
   error = EError::EERROR;
-  firstChar = 0;
+  firstNode = nullptr;
   cMatch = 0;
   global_pattern = nullptr;
 #ifdef COLORERMODE
@@ -169,30 +169,40 @@ EError CRegExp::setRELow(const UnicodeString& expr)
 void CRegExp::optimize()
 {
   SRegInfo* next = tree_root;
-  firstChar = BAD_WCHAR;
-  firstMetaChar = EMetaSymbols::ReBadMeta;
+  firstNode = nullptr;
   while (next) {
     if (next->op == EOps::ReBrackets) {
       next = next->un.param;
       continue;
     }
-    /*    if (next->op == EOps::ReMetaSymb &&
-            next->un.metaSymbol >= ReWBound && next->un.metaSymbol < ReChrLast){
+    if (next->op == EOps::ReAhead || next->op == EOps::ReNAhead ||
+        next->op == EOps::ReBehind || next->op == EOps::ReNBehind) {
+      next = next->next;
+      continue;
+    }
+    if (next->op == EOps::ReMetaSymb) {
+      firstNode = next;
+      switch (next->un.metaSymbol) {
+        case EMetaSymbols::ReSoL:
+        case EMetaSymbols::ReEoL:
+        case EMetaSymbols::ReWBound:
+        case EMetaSymbols::ReNWBound:
+        case EMetaSymbols::RePreNW:
+#ifdef COLORERMODE
+        case EMetaSymbols::ReSoScheme:
+        case EMetaSymbols::ReStart:
+        case EMetaSymbols::ReEnd:
+#endif
           next = next->next;
           continue;
-        };*/
-    if (next->op == EOps::ReMetaSymb) {
-      if (next->un.metaSymbol != EMetaSymbols::ReSoL && next->un.metaSymbol != EMetaSymbols::ReWBound)
-        break;
-      firstMetaChar = next->un.metaSymbol;
+        default:
+          break;
+      }
       break;
     }
-    if (next->op == EOps::ReSymb) {
-      firstChar = next->un.symbol;
-      break;
-    }
-    if (next->op == EOps::ReWord) {
-      firstChar = (*next->un.word)[0];
+    if (next->op == EOps::ReSymb || next->op == EOps::ReWord ||
+        next->op == EOps::ReEnum || next->op == EOps::ReNEnum) {
+      firstNode = next;
     }
     break;
   }
@@ -1372,49 +1382,75 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
 
 bool CRegExp::canStartWith(wchar ch) const
 {
-  return firstChar == BAD_WCHAR || matchChars(ch, firstChar);
+  if (!firstNode) {
+    return true;
+  }
+  switch (firstNode->op) {
+    case EOps::ReSymb:
+      return matchChars(ch, firstNode->un.symbol);
+    case EOps::ReWord:
+      return matchChars(ch, (*firstNode->un.word)[0]);
+    case EOps::ReEnum:
+      return firstNode->un.charclass->contains(ch);
+    case EOps::ReNEnum:
+      return !firstNode->un.charclass->contains(ch);
+    case EOps::ReMetaSymb:
+      switch (firstNode->un.metaSymbol) {
+        case EMetaSymbols::ReAnyChr:
+          return singleLine || (ch != 0x0A && ch != 0x0B && ch != 0x0C && ch != 0x0D &&
+                                ch != 0x85 && ch != 0x2028 && ch != 0x2029);
+        case EMetaSymbols::ReDigit:
+          return Character::isDigit(ch);
+        case EMetaSymbols::ReNDigit:
+          return !Character::isDigit(ch);
+        case EMetaSymbols::ReWordSymb:
+          return Character::isLetterOrDigitOrUnderscore(ch);
+        case EMetaSymbols::ReNWordSymb:
+          return !Character::isLetterOrDigitOrUnderscore(ch);
+        case EMetaSymbols::ReWSpace:
+          return Character::isWhitespace(ch);
+        case EMetaSymbols::ReNWSpace:
+          return !Character::isWhitespace(ch);
+        case EMetaSymbols::ReUCase:
+          return Character::isUpperCase(ch);
+        case EMetaSymbols::ReNUCase:
+          return Character::isLowerCase(ch);
+        default:
+          return true;
+      }
+    default:
+      return true;
+  }
 }
 
 inline bool CRegExp::quickCheck(int toParse)
 {
-  if (firstChar != BAD_WCHAR) {
-    return toParse < end && matchChars((*global_pattern)[toParse], firstChar);
-  }
-  if (firstMetaChar != EMetaSymbols::ReBadMeta)
-    switch (firstMetaChar) {
-      case EMetaSymbols::ReSoL:
-        if (toParse != 0)
-          return false;
-        return true;
+  switch (firstNode->op) {
+    case EOps::ReSymb:
+      return toParse < end && matchChars((*global_pattern)[toParse], firstNode->un.symbol);
+    case EOps::ReWord:
+      return toParse < end && matchChars((*global_pattern)[toParse], (*firstNode->un.word)[0]);
+    case EOps::ReEnum:
+    case EOps::ReNEnum:
+      return toParse < end &&
+             (firstNode->un.charclass->contains((*global_pattern)[toParse]) ==
+              (firstNode->op == EOps::ReEnum));
+    case EOps::ReMetaSymb:
+      switch (firstNode->un.metaSymbol) {
 #ifdef COLORERMODE
-      case EMetaSymbols::ReSoScheme:
-        if (toParse != schemeStart)
-          return false;
-        return true;
+        case EMetaSymbols::ReStart:
+        case EMetaSymbols::ReEnd:
+          return true;
 #endif
-        //    case ReWBound:
-        //      return relocale->cl_isword(*toParse) && (toParse == start ||
-        //      !relocale->cl_isword(*(toParse-1)));
-      case EMetaSymbols::ReBadMeta:
-      case EMetaSymbols::ReAnyChr:
-      case EMetaSymbols::ReEoL:
-      case EMetaSymbols::ReDigit:
-      case EMetaSymbols::ReNDigit:
-      case EMetaSymbols::ReWordSymb:
-      case EMetaSymbols::ReNWordSymb:
-      case EMetaSymbols::ReWSpace:
-      case EMetaSymbols::ReNWSpace:
-      case EMetaSymbols::ReUCase:
-      case EMetaSymbols::ReNUCase:
-      case EMetaSymbols::ReWBound:
-      case EMetaSymbols::ReNWBound:
-      case EMetaSymbols::RePreNW:
-      case EMetaSymbols::ReStart:
-      case EMetaSymbols::ReEnd:
-      case EMetaSymbols::ReChrLast:
-        break;
-    }
-  return true;
+        case EMetaSymbols::ReBadMeta:
+        case EMetaSymbols::ReChrLast:
+          return true;
+        default:
+          return checkMetaSymbol(firstNode->un.metaSymbol, toParse);
+      }
+    default:
+      return true;
+  }
 }
 
 inline bool CRegExp::parseRE(int pos)
@@ -1424,7 +1460,7 @@ inline bool CRegExp::parseRE(int pos)
 
   int toParse = pos;
 
-  if (!positionMoves && (firstChar != BAD_WCHAR || firstMetaChar != EMetaSymbols::ReBadMeta) && !quickCheck(toParse))
+  if (!positionMoves && firstNode && !quickCheck(toParse))
     return false;
 
   matches->reset();

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -444,11 +444,9 @@ EError CRegExp::setStructs(SRegInfo*& re, const UnicodeString& expr, int& retPos
         return EError::EBRACKETS;
       if (comma == -1)
         comma = en;
-      UnicodeString ds = UnicodeString(expr, st, comma - st);
-      next->s = UnicodeTools::getNumber(&ds);
-      UnicodeString de = UnicodeString(expr, comma + 1, en - comma - 1);
+      next->s = UnicodeTools::getNumber(&expr, st, comma - st);
       if (comma != en)
-        next->e = UnicodeTools::getNumber(&de);
+        next->e = UnicodeTools::getNumber(&expr, comma + 1, en - comma - 1);
       else
         next->e = next->s;
       if (next->e == -1)
@@ -919,7 +917,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
               continue;
             }
             if (ignoreCase) {
-              if (UStr::caseCompare(UnicodeString(pattern, toParse, wlen), *re->un.word) != 0) {
+              if (UStr::caseCompare(pattern, toParse, wlen, *re->un.word) != 0) {
                 check_stack(false, &re, &prev, &toParse, &leftenter, &action);
                 continue;
               }

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -671,10 +671,9 @@ bool CRegExp::isWordBoundary(int toParse)
 {
   int before = 0;
   int after = 0;
-  if (toParse < end && (Character::isLetterOrDigit((*global_pattern)[toParse]) || (*global_pattern)[toParse] == '_'))
+  if (toParse < end && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse]))
     after = 1;
-  if (toParse > 0 &&
-      (Character::isLetterOrDigit((*global_pattern)[toParse - 1]) || (*global_pattern)[toParse - 1] == '_'))
+  if (toParse > 0 && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse - 1]))
     before = 1;
   return before + after == 1;
 }
@@ -731,12 +730,12 @@ bool CRegExp::checkMetaSymbol(EMetaSymbols symb, int& toParse)
       toParse++;
       return true;
     case EMetaSymbols::ReWordSymb:
-      if (toParse >= end || !(Character::isLetterOrDigit(pattern[toParse]) || pattern[toParse] == '_'))
+      if (toParse >= end || !Character::isLetterOrDigitOrUnderscore(pattern[toParse]))
         return false;
       toParse++;
       return true;
     case EMetaSymbols::ReNWordSymb:
-      if (toParse >= end || Character::isLetterOrDigit(pattern[toParse]) || pattern[toParse] == '_')
+      if (toParse >= end || Character::isLetterOrDigitOrUnderscore(pattern[toParse]))
         return false;
       toParse++;
       return true;

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -1077,21 +1077,14 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
                 check_stack(false, &re, &prev, &toParse, &leftenter, &action);
                 continue;
               }
-              toParse += wlen;
             }
             else {
-              br = false;
-              for (i = 0; i < wlen; i++) {
-                if (pattern[toParse + i] != (*re->un.word)[i]) {
-                  check_stack(false, &re, &prev, &toParse, &leftenter, &action);
-                  br = true;
-                  break;
-                }
-              }
-              if (br)
+              if (pattern.compare(toParse, wlen, *re->un.word) != 0) {
+                check_stack(false, &re, &prev, &toParse, &leftenter, &action);
                 continue;
-              toParse += wlen;
+              }
             }
+            toParse += wlen;
             break;
           case EOps::ReEnum:
             if (toParse >= end) {

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -105,6 +105,7 @@ CRegExp::~CRegExp()
 
 bool CRegExp::matchChars(wchar one, wchar another) const
 {
+  // сознательное упрощение. правильнее дополнительно сравнивать toUpperCase, т.к. для Turkish I/ı и части Unicode это разное поведение
   return one == another ||
     (ignoreCase && Character::toLowerCase(one) == Character::toLowerCase(another));
 }

--- a/src/colorer/cregexp/cregexp.h
+++ b/src/colorer/cregexp/cregexp.h
@@ -2,6 +2,7 @@
 #define COLORER_CREGEXP_H
 
 #include "colorer/Common.h"
+#include <array>
 
 /**
     @addtogroup cregexp Regular Expressions
@@ -346,6 +347,8 @@ class CRegExp
   SRegInfo* tree_root = nullptr;
   EError error = EError::EOK;
   SRegInfo* firstNode = nullptr;
+  std::array<uint64_t, 2> firstCharMask = {};
+  bool firstCharMaskUseful = false;
 #ifdef COLORERMODE
   CRegExp* backRE = nullptr;
   const UnicodeString* backStr = nullptr;
@@ -372,6 +375,14 @@ class CRegExp
   EError setStructs(SRegInfo*&, const UnicodeString& expr, int& endPos);
 
   bool matchChars(wchar one, wchar another) const;
+  struct FirstChars
+  {
+    std::array<uint64_t, 2> mask = {};
+    bool nullable = false;
+  };
+  FirstChars analyzeFirstChars(const SRegInfo* re) const;
+  FirstChars firstCharsForNode(const SRegInfo* re) const;
+  void addFirstChar(FirstChars& result, wchar ch) const;
   void optimize();
   bool quickCheck(int toParse);
   bool isWordBoundary(int toParse);

--- a/src/colorer/cregexp/cregexp.h
+++ b/src/colorer/cregexp/cregexp.h
@@ -121,6 +121,8 @@ enum class EError { EOK = 0, EERROR, ESYNTAX, EBRACKETS, EENUM, EOP };
 /// @ingroup cregexp
 struct SMatches
 {
+  SMatches() : cMatch(0), cnMatch(0) { s[0] = e[0] = 0; }
+
   int s[MATCHES_NUM];
   int e[MATCHES_NUM];
   int cMatch;

--- a/src/colorer/cregexp/cregexp.h
+++ b/src/colorer/cregexp/cregexp.h
@@ -351,6 +351,7 @@ class CRegExp
   EError setRELow(const UnicodeString& re);
   EError setStructs(SRegInfo*&, const UnicodeString& expr, int& endPos);
 
+  bool matchChars(wchar one, wchar another) const;
   void optimize();
   bool quickCheck(int toParse);
   bool isWordBoundary(int toParse);

--- a/src/colorer/cregexp/cregexp.h
+++ b/src/colorer/cregexp/cregexp.h
@@ -121,14 +121,33 @@ enum class EError { EOK = 0, EERROR, ESYNTAX, EBRACKETS, EENUM, EOP };
 /// @ingroup cregexp
 struct SMatches
 {
-  SMatches() : cMatch(0), cnMatch(0) { s[0] = e[0] = 0; }
+  SMatches()
+  {
+    reset();
+  }
+  void reset()
+  {
+    s[0] = e[0] = -1;
+    cMatch = 0;
+    topse = 0;
+#if !defined NAMED_MATCHES_IN_HASH
+    ns[0] = ne[0] = -1;
+    cnMatch = 0;
+    topnse = 0;
+#endif
+  }
 
+  void topseSanitize(int cur); // use before accessing s[cur]/e[cur] to ensure their lazy inited to -1
   int s[MATCHES_NUM];
   int e[MATCHES_NUM];
+  int topse;
   int cMatch;
+
 #if !defined NAMED_MATCHES_IN_HASH
+  void topnseSanitize(int cur); // use before accessing ns[cur]/ne[cur] to ensure their lazy inited to -1
   int ns[NAMED_MATCHES_NUM];
   int ne[NAMED_MATCHES_NUM];
+  int topnse;
   int cnMatch;
 #endif
 };
@@ -340,6 +359,7 @@ class CRegExp
 
   SMatches* matches = nullptr;
   int cMatch = 0;
+
 #if !defined NAMED_MATCHES_IN_HASH
   UnicodeString* brnames[NAMED_MATCHES_NUM] = {};
   int cnMatch = 0;

--- a/src/colorer/cregexp/cregexp.h
+++ b/src/colorer/cregexp/cregexp.h
@@ -335,6 +335,7 @@ class CRegExp
   bool parse(const UnicodeString* str, int pos, int eol, SMatches* mtch, int soscheme = 0,
              int moves = -1);
 #endif
+  bool canStartWith(wchar ch) const;
 
  private:
   bool ignoreCase = false;

--- a/src/colorer/cregexp/cregexp.h
+++ b/src/colorer/cregexp/cregexp.h
@@ -345,8 +345,7 @@ class CRegExp
   bool multiLine = false;
   SRegInfo* tree_root = nullptr;
   EError error = EError::EOK;
-  UChar firstChar = 0;
-  EMetaSymbols firstMetaChar = EMetaSymbols::ReBadMeta;
+  SRegInfo* firstNode = nullptr;
 #ifdef COLORERMODE
   CRegExp* backRE = nullptr;
   const UnicodeString* backStr = nullptr;

--- a/src/colorer/cregexp/cregexp.h
+++ b/src/colorer/cregexp/cregexp.h
@@ -375,7 +375,6 @@ class CRegExp
   void optimize();
   bool quickCheck(int toParse);
   bool isWordBoundary(int toParse);
-  bool isNWordBoundary(int toParse);
   bool checkMetaSymbol(EMetaSymbols metaSymbol, int& toParse);
   bool lowParse(SRegInfo* re, SRegInfo* prev, int toParse);
   bool parseRE(int toParse);

--- a/src/colorer/parsers/FileTypeChooser.cpp
+++ b/src/colorer/parsers/FileTypeChooser.cpp
@@ -27,7 +27,7 @@ CRegExp* FileTypeChooser::getRE() const
 
 double FileTypeChooser::calcPriority(const UnicodeString* string) const
 {
-  SMatches match {};
+  SMatches match;
   if (string != nullptr && m_reg_matcher->parse(string, &match)) {
     return m_priority;
   }

--- a/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -774,7 +774,6 @@ void HrcLibrary::Impl::parseSchemeKeywords(SchemeImpl* scheme, const XMLNode& el
   loopSchemeKeywords(elem, scheme, scheme_node.get(), region);
   scheme_node->kwList->firstChar->freeze();
 
-  // TODO unique keywords in list
   scheme_node->kwList->sortList();
   scheme_node->kwList->substrIndex();
   scheme->nodes.push_back(std::move(scheme_node));
@@ -875,17 +874,16 @@ void HrcLibrary::Impl::addSchemeKeyword(const XMLNode& elem, const SchemeImpl* s
     rgn = getNCRegion(&elem, hrcWordAttrRegion);
   }
 
+  auto keyword = std::make_unique<UnicodeString>(keyword_value);
+  if (!scheme_node->kwList->matchCase) {
+      keyword->toLower();
+  }
   KeywordInfo& list = scheme_node->kwList->kwList[scheme_node->kwList->count];
-  list.keyword = std::make_unique<UnicodeString>(keyword_value);
+  list.keyword = std::move(keyword);
   list.region = rgn;
   list.isSymbol = keyword_type == KeywordInfo::KeywordType::KT_SYMB;
   auto* first_char = scheme_node->kwList->firstChar.get();
   first_char->add(keyword_value[0]);
-  if (!scheme_node->kwList->matchCase) {
-    first_char->add(Character::toLowerCase(keyword_value[0]));
-    first_char->add(Character::toUpperCase(keyword_value[0]));
-    first_char->add(Character::toTitleCase(keyword_value[0]));
-  }
   scheme_node->kwList->count++;
   scheme_node->kwList->minKeywordLength = std::min(scheme_node->kwList->minKeywordLength, list.keyword->length());
 }

--- a/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -1026,6 +1026,23 @@ void HrcLibrary::Impl::updateLinks()
     }
   }
 
+  const auto canStartWith = [](const SchemeNode* node, wchar ch) {
+    switch (node->type) {
+      case SchemeNode::SchemeNodeType::SNT_RE:
+        return static_cast<const SchemeNodeRegexp*>(node)->start->canStartWith(ch);
+      case SchemeNode::SchemeNodeType::SNT_BLOCK:
+        return static_cast<const SchemeNodeBlock*>(node)->start->canStartWith(ch);
+      case SchemeNode::SchemeNodeType::SNT_KEYWORDS: {
+        const auto* keywords = static_cast<const SchemeNodeKeywords*>(node)->kwList.get();
+        return keywords->count != 0 && keywords->firstChar->contains(
+          keywords->matchCase ? ch : Character::toLowerCase(ch));
+      }
+      case SchemeNode::SchemeNodeType::SNT_INHERIT:
+        return true;
+    }
+    return true;
+  };
+
   for (const auto& [key, scheme] : schemeHash) {
     scheme->searchNodes.clear();
     for (const auto& node : scheme->nodes) {
@@ -1039,6 +1056,25 @@ void HrcLibrary::Impl::updateLinks()
         }
       }
       scheme->searchNodes.push_back(node.get());
+    }
+
+    scheme->searchDispatch.reset();
+    if (scheme->searchNodes.size() >= 2) {
+      auto dispatch = std::make_unique<SchemeImpl::SearchDispatch>();
+      dispatch->masks.resize(scheme->searchNodes.size());
+      size_t candidates = 0;
+      for (size_t i = 0; i < scheme->searchNodes.size(); i++) {
+        auto* node = scheme->searchNodes[i];
+        for (uint32_t ch = 0; ch < 128; ch++) {
+          if (canStartWith(node, static_cast<wchar>(ch))) {
+            dispatch->masks[i][ch / 64] |= uint64_t {1} << (ch % 64);
+            candidates++;
+          }
+        }
+      }
+      if (candidates * 4 <= scheme->searchNodes.size() * 128 * 3) {
+        scheme->searchDispatch = std::move(dispatch);
+      }
     }
   }
 }

--- a/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -883,7 +883,7 @@ void HrcLibrary::Impl::addSchemeKeyword(const XMLNode& elem, const SchemeImpl* s
   list.region = rgn;
   list.isSymbol = keyword_type == KeywordInfo::KeywordType::KT_SYMB;
   auto* first_char = scheme_node->kwList->firstChar.get();
-  first_char->add(keyword_value[0]);
+  first_char->add((*list.keyword)[0]);
   scheme_node->kwList->count++;
   scheme_node->kwList->minKeywordLength = std::min(scheme_node->kwList->minKeywordLength, list.keyword->length());
 }

--- a/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -1,4 +1,6 @@
 #include "colorer/parsers/HrcLibraryImpl.h"
+
+#include <algorithm>
 #include <memory>
 #include "colorer/base/XmlTagDefs.h"
 #include "colorer/parsers/FileTypeImpl.h"
@@ -1011,6 +1013,9 @@ void HrcLibrary::Impl::updateLinks()
           updateSchemeLink(snode_inherit->schemeName, &snode_inherit->scheme, 1, scheme);
           for (auto* vt : snode_inherit->virtualEntryVector) {
             updateSchemeLink(vt->virtSchemeName, &vt->virtScheme, 2, scheme);
+            if (vt->virtScheme) {
+              vt->virtScheme->virtualTarget = true;
+            }
             updateSchemeLink(vt->substSchemeName, &vt->substScheme, 3, scheme);
           }
         }
@@ -1019,6 +1024,26 @@ void HrcLibrary::Impl::updateLinks()
       if (structureChanged) {
         break;
       }
+    }
+  }
+
+  for (const auto& [key, scheme] : schemeHash) {
+    scheme->searchNodes.clear();
+    for (const auto& node : scheme->nodes) {
+      if (node->type == SchemeNode::SchemeNodeType::SNT_INHERIT) {
+        auto* inherit = static_cast<SchemeNodeInherit*>(node.get());
+        if (inherit->scheme && inherit->virtualEntryVector.empty() &&
+            !inherit->scheme->virtualTarget && std::none_of(
+              inherit->scheme->nodes.begin(), inherit->scheme->nodes.end(), [](const auto& node) {
+                return node->type == SchemeNode::SchemeNodeType::SNT_INHERIT;
+              })) {
+          for (const auto& inheritedNode : inherit->scheme->nodes) {
+            scheme->searchNodes.push_back(inheritedNode.get());
+          }
+          continue;
+        }
+      }
+      scheme->searchNodes.push_back(node.get());
     }
   }
 }

--- a/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -1,6 +1,8 @@
 #include "colorer/parsers/HrcLibraryImpl.h"
 
+#include <functional>
 #include <memory>
+#include <unordered_map>
 #include "colorer/base/XmlTagDefs.h"
 #include "colorer/parsers/FileTypeImpl.h"
 #include "colorer/xml/XmlReader.h"
@@ -1026,22 +1028,20 @@ void HrcLibrary::Impl::updateLinks()
     }
   }
 
-  const auto canStartWith = [](const SchemeNode* node, wchar ch) {
-    switch (node->type) {
-      case SchemeNode::SchemeNodeType::SNT_RE:
-        return static_cast<const SchemeNodeRegexp*>(node)->start->canStartWith(ch);
-      case SchemeNode::SchemeNodeType::SNT_BLOCK:
-        return static_cast<const SchemeNodeBlock*>(node)->start->canStartWith(ch);
-      case SchemeNode::SchemeNodeType::SNT_KEYWORDS: {
-        const auto* keywords = static_cast<const SchemeNodeKeywords*>(node)->kwList.get();
-        return keywords->count != 0 && keywords->firstChar->contains(
-          keywords->matchCase ? ch : Character::toLowerCase(ch));
+  std::unordered_map<const SchemeImpl*, std::vector<const SchemeImpl*>> virtualSubstitutions;
+  for (const auto& [key, scheme] : schemeHash) {
+    for (const auto& node : scheme->nodes) {
+      if (node->type != SchemeNode::SchemeNodeType::SNT_INHERIT) {
+        continue;
       }
-      case SchemeNode::SchemeNodeType::SNT_INHERIT:
-        return true;
+      const auto* inherit = static_cast<const SchemeNodeInherit*>(node.get());
+      for (const auto* entry : inherit->virtualEntryVector) {
+        if (entry->virtScheme && entry->substScheme) {
+          virtualSubstitutions[entry->virtScheme].push_back(entry->substScheme);
+        }
+      }
     }
-    return true;
-  };
+  }
 
   for (const auto& [key, scheme] : schemeHash) {
     scheme->searchNodes.clear();
@@ -1057,22 +1057,72 @@ void HrcLibrary::Impl::updateLinks()
       }
       scheme->searchNodes.push_back(node.get());
     }
+  }
 
-    scheme->searchDispatch.reset();
-    if (scheme->searchNodes.size() >= 2) {
-      auto dispatch = std::make_unique<SchemeImpl::SearchDispatch>();
-      dispatch->masks.resize(scheme->searchNodes.size());
-      size_t candidates = 0;
-      for (size_t i = 0; i < scheme->searchNodes.size(); i++) {
-        auto* node = scheme->searchNodes[i];
-        for (uint32_t ch = 0; ch < 128; ch++) {
-          if (canStartWith(node, static_cast<wchar>(ch))) {
-            dispatch->masks[i][ch / 64] |= uint64_t {1} << (ch % 64);
-            candidates++;
+  std::unordered_map<const SchemeImpl*, std::array<uint8_t, 128>> startCache;
+  std::function<bool(const SchemeImpl*, wchar)> schemeCanStartWith;
+  const auto nodeCanStartWith = [&schemeCanStartWith](const SchemeNode* node, wchar ch) {
+    switch (node->type) {
+      case SchemeNode::SchemeNodeType::SNT_RE:
+        return static_cast<const SchemeNodeRegexp*>(node)->start->canStartWith(ch);
+      case SchemeNode::SchemeNodeType::SNT_BLOCK:
+        return static_cast<const SchemeNodeBlock*>(node)->start->canStartWith(ch);
+      case SchemeNode::SchemeNodeType::SNT_KEYWORDS: {
+        const auto* keywords = static_cast<const SchemeNodeKeywords*>(node)->kwList.get();
+        return keywords->count != 0 && keywords->firstChar->contains(
+          keywords->matchCase ? ch : Character::toLowerCase(ch));
+      }
+      case SchemeNode::SchemeNodeType::SNT_INHERIT: {
+        const auto* inherit = static_cast<const SchemeNodeInherit*>(node);
+        return !inherit->scheme || schemeCanStartWith(inherit->scheme, ch);
+      }
+    }
+    return true;
+  };
+
+  schemeCanStartWith = [&startCache, &virtualSubstitutions, &nodeCanStartWith, &schemeCanStartWith](
+                         const SchemeImpl* scheme, wchar ch) {
+    auto& state = startCache[scheme][static_cast<uint32_t>(ch)];
+    if (state != 0) {
+      return state == 1 || state == 3;
+    }
+    state = 1;
+    bool result = false;
+    for (const auto* node : scheme->searchNodes) {
+      if (nodeCanStartWith(node, ch)) {
+        result = true;
+        break;
+      }
+    }
+    if (!result) {
+      const auto substitutions = virtualSubstitutions.find(scheme);
+      if (substitutions != virtualSubstitutions.end()) {
+        for (const auto* substitution : substitutions->second) {
+          if (schemeCanStartWith(substitution, ch)) {
+            result = true;
+            break;
           }
         }
       }
-      if (candidates * 4 <= scheme->searchNodes.size() * 128 * 3) {
+    }
+    state = result ? 3 : 2;
+    return result;
+  };
+
+  for (const auto& [key, scheme] : schemeHash) {
+    scheme->searchDispatch.reset();
+    if (scheme->searchNodes.size() >= 2 && scheme->searchNodes.size() <= UINT16_MAX) {
+      auto dispatch = std::make_unique<SchemeImpl::SearchDispatch>();
+      for (uint32_t ch = 0; ch < 128; ch++) {
+        dispatch->offsets[ch] = static_cast<uint32_t>(dispatch->nodeIndexes.size());
+        for (uint32_t i = 0; i < scheme->searchNodes.size(); i++) {
+          if (nodeCanStartWith(scheme->searchNodes[i], static_cast<wchar>(ch))) {
+            dispatch->nodeIndexes.push_back(i);
+          }
+        }
+      }
+      dispatch->offsets[128] = static_cast<uint32_t>(dispatch->nodeIndexes.size());
+      if (dispatch->nodeIndexes.size() * 4 <= scheme->searchNodes.size() * 128 * 3) {
         scheme->searchDispatch = std::move(dispatch);
       }
     }

--- a/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -1,6 +1,5 @@
 #include "colorer/parsers/HrcLibraryImpl.h"
 
-#include <algorithm>
 #include <memory>
 #include "colorer/base/XmlTagDefs.h"
 #include "colorer/parsers/FileTypeImpl.h"
@@ -1032,11 +1031,7 @@ void HrcLibrary::Impl::updateLinks()
     for (const auto& node : scheme->nodes) {
       if (node->type == SchemeNode::SchemeNodeType::SNT_INHERIT) {
         auto* inherit = static_cast<SchemeNodeInherit*>(node.get());
-        if (inherit->scheme && inherit->virtualEntryVector.empty() &&
-            !inherit->scheme->virtualTarget && std::none_of(
-              inherit->scheme->nodes.begin(), inherit->scheme->nodes.end(), [](const auto& node) {
-                return node->type == SchemeNode::SchemeNodeType::SNT_INHERIT;
-              })) {
+        if (inherit->scheme && inherit->virtualEntryVector.empty() && !inherit->scheme->virtualTarget) {
           for (const auto& inheritedNode : inherit->scheme->nodes) {
             scheme->searchNodes.push_back(inheritedNode.get());
           }

--- a/src/colorer/parsers/KeywordList.cpp
+++ b/src/colorer/parsers/KeywordList.cpp
@@ -1,4 +1,5 @@
 #include "colorer/parsers/KeywordList.h"
+#include <algorithm>
 
 KeywordList::KeywordList(size_t list_size)
 {
@@ -11,27 +12,22 @@ KeywordList::~KeywordList()
   delete[] kwList;
 }
 
-int kwCompare(const void* e1, const void* e2)
+void KeywordList::sortList() // sort and remove dups
 {
-  return ((KeywordInfo*) e1)->keyword->compare(*((KeywordInfo*) e2)->keyword);
-}
-
-int kwCompareI(const void* e1, const void* e2)
-{
-  return UStr::caseCompare(*((KeywordInfo*) e1)->keyword, *((KeywordInfo*) e2)->keyword);
-}
-
-void KeywordList::sortList()
-{
-  if (count < 2) {
-    return;
-  }
-
-  if (matchCase) {
-    qsort((void*) kwList, count, sizeof(KeywordInfo), &kwCompare);
-  } else {
-    qsort((void*) kwList, count, sizeof(KeywordInfo), &kwCompareI);
-  }
+  std::sort(kwList, kwList + count, [&](const KeywordInfo& a, const KeywordInfo& b) {
+      int cmp = a.keyword->compare(*b.keyword);
+      if (cmp != 0) {
+        return cmp < 0;
+      }
+      if (a.region != b.region) {
+        return a.region < b.region;
+      }
+      return a.isSymbol < b.isSymbol;
+  });
+  KeywordInfo* new_end = std::unique(kwList, kwList + count, [&](const KeywordInfo& a, const KeywordInfo& b) {
+      return a.region == b.region && a.isSymbol == b.isSymbol && a.keyword->compare(*b.keyword) == 0; // indexOfShorter is irrelevant now
+  });
+  count = new_end - kwList;
 }
 
 /* Searches previous elements num with same partial name
@@ -43,29 +39,23 @@ void KeywordList::sortList()
 */
 void KeywordList::substrIndex()
 {
+  for (int i = 0; i < count; i++) {
+    if (kwList[i].isSymbol) {
+      hasSymbols = true;
+    } else {
+      hasNonSymbols = true;
+    }
+  }
   for (int i = count - 1; i > 0; i--) {
     for (int ii = i - 1; ii >= 0; ii--) {
-      if (matchCase) {
-        if ((*kwList[ii].keyword)[0] != (*kwList[i].keyword)[0]) {
-          break;
-        }
-        if (kwList[ii].keyword->length() < kwList[i].keyword->length() &&
-            kwList[i].keyword->compare(0, kwList[ii].keyword->length(), *kwList[ii].keyword) == 0)
-        {
-          kwList[i].indexOfShorter = ii;
-          break;
-        }
+      if ((*kwList[ii].keyword)[0] != (*kwList[i].keyword)[0]) {
+        break;
       }
-      else {
-        if (Character::toLowerCase((*kwList[ii].keyword)[0]) != Character::toLowerCase((*kwList[i].keyword)[0])) {
-          break;
-        }
-        if (kwList[ii].keyword->length() < kwList[i].keyword->length() &&
-            UStr::caseCompare(*kwList[i].keyword, 0, kwList[ii].keyword->length(), *kwList[ii].keyword) == 0)
-        {
-          kwList[i].indexOfShorter = ii;
-          break;
-        }
+      if (kwList[ii].keyword->length() < kwList[i].keyword->length() &&
+          kwList[i].keyword->compare(0, kwList[ii].keyword->length(), *kwList[ii].keyword) == 0)
+      {
+        kwList[i].indexOfShorter = ii;
+        break;
       }
     }
   }

--- a/src/colorer/parsers/KeywordList.cpp
+++ b/src/colorer/parsers/KeywordList.cpp
@@ -50,7 +50,7 @@ void KeywordList::substrIndex()
           break;
         }
         if (kwList[ii].keyword->length() < kwList[i].keyword->length() &&
-            UnicodeString(*kwList[i].keyword, 0, kwList[ii].keyword->length()).compare(*kwList[ii].keyword) == 0)
+            kwList[i].keyword->compare(0, kwList[ii].keyword->length(), *kwList[ii].keyword) == 0)
         {
           kwList[i].indexOfShorter = ii;
           break;
@@ -61,8 +61,7 @@ void KeywordList::substrIndex()
           break;
         }
         if (kwList[ii].keyword->length() < kwList[i].keyword->length() &&
-            UStr::caseCompare(UnicodeString(*kwList[i].keyword, 0, kwList[ii].keyword->length()),
-                              *kwList[ii].keyword) == 0)
+            UStr::caseCompare(*kwList[i].keyword, 0, kwList[ii].keyword->length(), *kwList[ii].keyword) == 0)
         {
           kwList[i].indexOfShorter = ii;
           break;

--- a/src/colorer/parsers/KeywordList.cpp
+++ b/src/colorer/parsers/KeywordList.cpp
@@ -27,7 +27,7 @@ void KeywordList::sortList() // sort and remove dups
   KeywordInfo* new_end = std::unique(kwList, kwList + count, [&](const KeywordInfo& a, const KeywordInfo& b) {
       return a.region == b.region && a.isSymbol == b.isSymbol && a.keyword->compare(*b.keyword) == 0; // indexOfShorter is irrelevant now
   });
-  count = new_end - kwList;
+  count = static_cast<int>(new_end - kwList);
 }
 
 /* Searches previous elements num with same partial name

--- a/src/colorer/parsers/KeywordList.h
+++ b/src/colorer/parsers/KeywordList.h
@@ -26,6 +26,8 @@ class KeywordList
 {
  public:
   bool matchCase = false;
+  bool hasSymbols = false;
+  bool hasNonSymbols = false;
   int count = 0;
   int minKeywordLength = INT_MAX;
   std::unique_ptr<CharacterClass> firstChar;

--- a/src/colorer/parsers/SchemeImpl.h
+++ b/src/colorer/parsers/SchemeImpl.h
@@ -35,7 +35,8 @@ class SchemeImpl : public Scheme
  protected:
   struct SearchDispatch
   {
-    std::vector<std::array<uint64_t, 2>> masks;
+    std::array<uint32_t, 129> offsets = {};
+    std::vector<uint16_t> nodeIndexes;
   };
 
   uUnicodeString schemeName;

--- a/src/colorer/parsers/SchemeImpl.h
+++ b/src/colorer/parsers/SchemeImpl.h
@@ -7,7 +7,6 @@
 #include <vector>
 #include "colorer/Scheme.h"
 #include "colorer/TextParser.h"
-#include "colorer/cregexp/cregexp.h"
 #include "colorer/parsers/SchemeNode.h"
 
 class FileType;

--- a/src/colorer/parsers/SchemeImpl.h
+++ b/src/colorer/parsers/SchemeImpl.h
@@ -1,6 +1,8 @@
 #ifndef COLORER_HRCPARSERPELPERS_H
 #define COLORER_HRCPARSERPELPERS_H
 
+#include <array>
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include "colorer/Scheme.h"
@@ -31,9 +33,15 @@ class SchemeImpl : public Scheme
   }
 
  protected:
+  struct SearchDispatch
+  {
+    std::vector<std::array<uint64_t, 2>> masks;
+  };
+
   uUnicodeString schemeName;
   std::vector<std::unique_ptr<SchemeNode>> nodes;
   std::vector<SchemeNode*> searchNodes;
+  std::unique_ptr<SearchDispatch> searchDispatch;
   FileType* fileType = nullptr;
   bool virtualTarget = false;
 

--- a/src/colorer/parsers/SchemeImpl.h
+++ b/src/colorer/parsers/SchemeImpl.h
@@ -33,7 +33,9 @@ class SchemeImpl : public Scheme
  protected:
   uUnicodeString schemeName;
   std::vector<std::unique_ptr<SchemeNode>> nodes;
+  std::vector<SchemeNode*> searchNodes;
   FileType* fileType = nullptr;
+  bool virtualTarget = false;
 
   explicit SchemeImpl(const UnicodeString* sn)
   {

--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -303,7 +303,7 @@ int TextParser::Impl::searchIN(SchemeNodeInherit* node, int no, int lowLen, int 
 
 int TextParser::Impl::searchRE(SchemeNodeRegexp* node, int /*no*/, int lowLen, int hiLen)
 {
-  SMatches match {};
+  SMatches match;
   if (!node->start->parse(str, gx, node->lowPriority ? lowLen : hiLen, &match, schemeStart)) {
     return MATCH_NOTHING;
   }
@@ -334,7 +334,7 @@ int TextParser::Impl::searchBL(SchemeNodeBlock* node, int no, int lowLen, int hi
   }
 
   // проверяем совпадение по регулярному выражению start
-  SMatches match {};
+  SMatches match;
   if (!node->start->parse(str, gx, node->lowPriority ? lowLen : hiLen, &match, schemeStart)) {
     return MATCH_NOTHING;
   }

--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -216,11 +216,11 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
 
     int8_t compare_result;
     if (node->kwList->matchCase) {
-      compare_result = node->kwList->kwList[pos].keyword->compare(UnicodeString(*str, gx, kwlen));
+      compare_result = -str->compare(gx, kwlen, *node->kwList->kwList[pos].keyword);
     }
     else {
       compare_result =
-          UStr::caseCompare(*node->kwList->kwList[pos].keyword, UnicodeString(*str, gx, kwlen));
+          -UStr::caseCompare(*str, gx, kwlen, *node->kwList->kwList[pos].keyword);
     }
 
     if (compare_result == 0 && right - left == 1) {

--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -459,22 +459,22 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
 #ifdef COLORER_USE_DEEPTRACE
   int idx = 0;
 #endif
-  uint32_t dispatchChar = 128;
+  size_t searchBegin = 0;
+  size_t searchEnd = cscheme->searchNodes.size();
+  bool useDispatch = false;
   if (cscheme->searchDispatch && gx < str->length()) {
     const auto ch = static_cast<uint32_t>((*str)[gx]);
     if (ch < 128) {
-      dispatchChar = ch;
+      searchBegin = cscheme->searchDispatch->offsets[ch];
+      searchEnd = cscheme->searchDispatch->offsets[ch + 1];
+      useDispatch = true;
     }
   }
-  for (size_t i = 0; i < cscheme->searchNodes.size(); i++) {
-    if (dispatchChar < 128 &&
-        !(cscheme->searchDispatch->masks[i][dispatchChar / 64] &
-          (uint64_t {1} << (dispatchChar % 64)))) {
-      continue;
-    }
-    auto* schemeNode = cscheme->searchNodes[i];
+  for (size_t i = searchBegin; i < searchEnd; i++) {
+    auto* schemeNode = cscheme->searchNodes[
+      useDispatch ? cscheme->searchDispatch->nodeIndexes[i] : i];
     COLORER_LOG_DEEPTRACE("[TextParserImpl] searchMatch: processing node:%/%, type:%", idx + 1,
-                         cscheme->searchNodes.size(),
+                         searchEnd - searchBegin,
                          SchemeNode::schemeNodeTypeNames[static_cast<int>(schemeNode->type)]);
     switch (schemeNode->type) {
       case SchemeNode::SchemeNodeType::SNT_INHERIT: {

--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -228,9 +228,8 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
       if (!node->kwList->kwList[pos].isSymbol) {
         if (!node->worddiv) {
           // default word bound
-          if ((gx > 0 && (Character::isLetterOrDigit((*str)[gx - 1]) || (*str)[gx - 1] == L'_')) ||
-              (gx + kwlen < lowlen &&
-               (Character::isLetterOrDigit((*str)[gx + kwlen]) || (*str)[gx + kwlen] == L'_')))
+          if ((gx > 0 && Character::isLetterOrDigitOrUnderscore((*str)[gx - 1])) ||
+              (gx + kwlen < lowlen && Character::isLetterOrDigitOrUnderscore((*str)[gx + kwlen])))
           {
             badbound = true;
           }

--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -459,13 +459,13 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
 #ifdef COLORER_USE_DEEPTRACE
   int idx = 0;
 #endif
-  for (auto const& schemeNode : cscheme->nodes) {
+  for (auto* schemeNode : cscheme->searchNodes) {
     COLORER_LOG_DEEPTRACE("[TextParserImpl] searchMatch: processing node:%/%, type:%", idx + 1,
-                         cscheme->nodes.size(),
+                         cscheme->searchNodes.size(),
                          SchemeNode::schemeNodeTypeNames[static_cast<int>(schemeNode->type)]);
     switch (schemeNode->type) {
       case SchemeNode::SchemeNodeType::SNT_INHERIT: {
-        auto schemeNodeInherit = static_cast<SchemeNodeInherit*>(schemeNode.get());
+        auto schemeNodeInherit = static_cast<SchemeNodeInherit*>(schemeNode);
         int re_result = searchIN(schemeNodeInherit, no, lowLen, hiLen);
         if (re_result != MATCH_NOTHING) {
           return re_result;
@@ -473,21 +473,21 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
         break;
       }
       case SchemeNode::SchemeNodeType::SNT_KEYWORDS: {
-        auto schemeNodeKe = static_cast<SchemeNodeKeywords*>(schemeNode.get());
+        auto schemeNodeKe = static_cast<SchemeNodeKeywords*>(schemeNode);
         if (searchKW(schemeNodeKe, no, lowLen, hiLen) == MATCH_RE) {
           return MATCH_RE;
         }
         break;
       }
       case SchemeNode::SchemeNodeType::SNT_RE: {
-        auto schemeNodeRe = static_cast<SchemeNodeRegexp*>(schemeNode.get());
+        auto schemeNodeRe = static_cast<SchemeNodeRegexp*>(schemeNode);
         if (searchRE(schemeNodeRe, no, lowLen, hiLen) == MATCH_RE) {
           return MATCH_RE;
         }
         break;
       }
       case SchemeNode::SchemeNodeType::SNT_BLOCK: {
-        auto schemeNodeBlock = static_cast<SchemeNodeBlock*>(schemeNode.get());
+        auto schemeNodeBlock = static_cast<SchemeNodeBlock*>(schemeNode);
         if (searchBL(schemeNodeBlock, no, lowLen, hiLen) != MATCH_NOTHING) {
           return MATCH_SCHEME;
         }

--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -278,7 +278,7 @@ int TextParser::Impl::searchIN(SchemeNodeInherit* node, int no, int lowLen, int 
 
   int re_result = MATCH_NOTHING;
   // ищем для текущей схемы возможную замену через virtual предыдущих inherit
-  SchemeImpl* ssubst = vtlist->pushvirt(node->scheme);
+  SchemeImpl* ssubst = node->scheme->virtualTarget ? vtlist->pushvirt(node->scheme) : nullptr;
   if (!ssubst) {
     // не нашли замену
     // помещаем текущий inherit в список для будущих замен. True - если поместили, не было
@@ -341,7 +341,7 @@ int TextParser::Impl::searchBL(SchemeNodeBlock* node, int no, int lowLen, int hi
   COLORER_LOG_DEEPTRACE("[TextParserImpl] Scheme matched. gx=%", gx);
   gx = match.e[0];
   // проверяем наличие замены через virtual для данной схемы
-  SchemeImpl* ssubst = vtlist->pushvirt(node->scheme);
+  SchemeImpl* ssubst = node->scheme->virtualTarget ? vtlist->pushvirt(node->scheme) : nullptr;
   if (!ssubst) {
     // замены нет, работаем с текущей
     ssubst = node->scheme;
@@ -459,7 +459,20 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
 #ifdef COLORER_USE_DEEPTRACE
   int idx = 0;
 #endif
-  for (auto* schemeNode : cscheme->searchNodes) {
+  uint32_t dispatchChar = 128;
+  if (cscheme->searchDispatch && gx < str->length()) {
+    const auto ch = static_cast<uint32_t>((*str)[gx]);
+    if (ch < 128) {
+      dispatchChar = ch;
+    }
+  }
+  for (size_t i = 0; i < cscheme->searchNodes.size(); i++) {
+    if (dispatchChar < 128 &&
+        !(cscheme->searchDispatch->masks[i][dispatchChar / 64] &
+          (uint64_t {1} << (dispatchChar % 64)))) {
+      continue;
+    }
+    auto* schemeNode = cscheme->searchNodes[i];
     COLORER_LOG_DEEPTRACE("[TextParserImpl] searchMatch: processing node:%/%, type:%", idx + 1,
                          cscheme->searchNodes.size(),
                          SchemeNode::schemeNodeTypeNames[static_cast<int>(schemeNode->type)]);

--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -266,6 +266,7 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
     }
   }
 
+  return MATCH_NOTHING;
 }
 
 int TextParser::Impl::searchIN(SchemeNodeInherit* node, int no, int lowLen, int hiLen)

--- a/src/colorer/parsers/TextParserImpl.cpp
+++ b/src/colorer/parsers/TextParserImpl.cpp
@@ -201,7 +201,22 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
     return MATCH_NOTHING;
   }
 
-  if (gx < lowlen && !node->kwList->firstChar->contains((*str)[gx])) {
+  UnicodeString *use_str = node->kwList->matchCase ? str : &str_lowercase;
+  bool leftbound_bad = false;
+  if (node->kwList->hasNonSymbols) {
+    if (gx > 0) {
+      if (!node->worddiv) { // default word bound
+        leftbound_bad = Character::isLetterOrDigitOrUnderscore((*use_str)[gx - 1]);
+      } else { // custom check for word bound
+        leftbound_bad = !node->worddiv->contains((*use_str)[gx - 1]);
+      }
+    }
+    if (leftbound_bad && !node->kwList->hasSymbols) {
+      return MATCH_NOTHING; // otherwise its just a waist of time
+    }
+  }
+
+  if (gx < lowlen && !node->kwList->firstChar->contains((*use_str)[gx])) {
     return MATCH_NOTHING;
   }
 
@@ -214,36 +229,23 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
       kwlen = lowlen - gx;
     }
 
-    int8_t compare_result;
-    if (node->kwList->matchCase) {
-      compare_result = -str->compare(gx, kwlen, *node->kwList->kwList[pos].keyword);
-    }
-    else {
-      compare_result =
-          -UStr::caseCompare(*str, gx, kwlen, *node->kwList->kwList[pos].keyword);
-    }
+    int8_t compare_result = -use_str->compare(gx, kwlen, *node->kwList->kwList[pos].keyword);
 
     if (compare_result == 0 && right - left == 1) {
-      bool badbound = false;
       if (!node->kwList->kwList[pos].isSymbol) {
-        if (!node->worddiv) {
-          // default word bound
-          if ((gx > 0 && Character::isLetterOrDigitOrUnderscore((*str)[gx - 1])) ||
-              (gx + kwlen < lowlen && Character::isLetterOrDigitOrUnderscore((*str)[gx + kwlen])))
-          {
-            badbound = true;
-          }
+        if (leftbound_bad) {
+          compare_result = -1;
         }
-        else {
-          // custom check for word bound
-          if ((gx > 0 && !node->worddiv->contains((*str)[gx - 1])) ||
-              (gx + kwlen < lowlen && !node->worddiv->contains((*str)[gx + kwlen])))
-          {
-            badbound = true;
+        // do similar check for right boundary each iteration cuz kwlen varies
+        else if (!node->worddiv) {
+          if (gx + kwlen < lowlen && Character::isLetterOrDigitOrUnderscore((*use_str)[gx + kwlen])) {
+            compare_result = -1;
           }
+        } else if (gx + kwlen < lowlen && !node->worddiv->contains((*use_str)[gx + kwlen])) {
+          compare_result = -1;
         }
       }
-      if (!badbound) {
+      if (compare_result == 0) {
         COLORER_LOG_DEEPTRACE("[TextParserImpl] KW matched. gx=%, region=%", gx,
                              node->kwList->kwList[pos].region->getName());
         addRegion(current_parse_line, gx, gx + kwlen, node->kwList->kwList[pos].region);
@@ -253,20 +255,17 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
     }
     if (right - left == 1) {
       left = node->kwList->kwList[pos].indexOfShorter;
-      if (left != -1) {
-        right = left + 1;
-        continue;
+      if (left == -1) {
+        return MATCH_NOTHING;
       }
-      break;
-    }
-    if (compare_result == 1) {
+      right = left + 1;
+    } else if (compare_result == 1) {
       right = pos;
-    }
-    else {  // if (compare_result == 0 || compare_result == -1)
+    } else {  // if (compare_result == 0 || compare_result == -1)
       left = pos;
     }
   }
-  return MATCH_NOTHING;
+
 }
 
 int TextParser::Impl::searchIN(SchemeNodeInherit* node, int no, int lowLen, int hiLen)
@@ -528,6 +527,8 @@ bool TextParser::Impl::colorize(CRegExp* root_end_re, bool lowContentPriority)
         stackLevel--;
         return true;
       }
+      str_lowercase = *str;
+      str_lowercase.toLower();
       regionHandler->clearLine(current_parse_line, str);
     }
     // hack to include invisible regions in start of block

--- a/src/colorer/parsers/TextParserImpl.h
+++ b/src/colorer/parsers/TextParserImpl.h
@@ -29,6 +29,7 @@ class TextParser::Impl
 
  private:
   UnicodeString* str = nullptr;
+  UnicodeString str_lowercase;
   int stackLevel = 0;
   int current_parse_line = 0;
   int gx = 0;

--- a/src/colorer/strings/icu/Character.cpp
+++ b/src/colorer/strings/icu/Character.cpp
@@ -20,9 +20,9 @@ bool Character::isLetter(UChar c)
   return u_isalpha(c);
 }
 
-bool Character::isLetterOrDigit(UChar c)
+bool Character::isLetterOrDigitOrUnderscore(UChar c)
 {
-  return u_isdigit(c) || u_isalpha(c);
+  return u_isdigit(c) || u_isalpha(c) || c == '_';
 }
 
 bool Character::isDigit(UChar c)

--- a/src/colorer/strings/icu/Character.h
+++ b/src/colorer/strings/icu/Character.h
@@ -10,7 +10,7 @@ class Character
   static bool isLowerCase(UChar c);
   static bool isUpperCase(UChar c);
   static bool isLetter(UChar c);
-  static bool isLetterOrDigit(UChar c);
+  static bool isLetterOrDigitOrUnderscore(UChar c);
   static bool isDigit(UChar c);
 
   static UChar toLowerCase(UChar c);

--- a/src/colorer/strings/icu/UStr.cpp
+++ b/src/colorer/strings/icu/UStr.cpp
@@ -245,6 +245,11 @@ int8_t UStr::caseCompare(const UnicodeString& str1, const UnicodeString& str2)
   return str1.caseCompare(str2, U_FOLD_CASE_DEFAULT);
 }
 
+int8_t UStr::caseCompare(const UnicodeString& str1, int str1_pos, int str1_len, const UnicodeString& str2)
+{
+  return str1.caseCompare(str1_pos, str1_len, str2, U_FOLD_CASE_DEFAULT);
+}
+
 int32_t UStr::indexOfIgnoreCase(const UnicodeString& str1, const UnicodeString& str2, int32_t pos)
 {
   auto tmp_str1 = str1;

--- a/src/colorer/strings/icu/UStr.h
+++ b/src/colorer/strings/icu/UStr.h
@@ -24,6 +24,8 @@ class UStr
   static bool HexToUInt(const UnicodeString& str_hex, unsigned int* result);
 
   static int8_t caseCompare(const UnicodeString& str1, const UnicodeString& str2);
+  static int8_t caseCompare(const UnicodeString& str1, int str1_pos, int str1_len, const UnicodeString& str2);
+
   static int32_t indexOfIgnoreCase(const UnicodeString& str1, const UnicodeString& str2, int32_t pos = 0);
 };
 

--- a/src/colorer/strings/icu/UnicodeTools.cpp
+++ b/src/colorer/strings/icu/UnicodeTools.cpp
@@ -14,14 +14,16 @@ int UnicodeTools::getHex(UChar c)
   return c;
 }
 
-int UnicodeTools::getHexNumber(const UnicodeString* pstr)
+int UnicodeTools::getHexNumber(const UnicodeString* pstr, int ofs, int len)
 {
   int r = 0;
   int num = 0;
   if (pstr == nullptr) {
     return -1;
   }
-  for (int i = (*pstr).length() - 1; i >= 0; i--) {
+  if (len < 0)
+    len = pstr->length();
+  for (int i = len - 1; i >= ofs; i--) {
     int d = getHex((*pstr)[i]);
     if (d == -1) {
       return -1;
@@ -32,13 +34,15 @@ int UnicodeTools::getHexNumber(const UnicodeString* pstr)
   return num;
 }
 
-int UnicodeTools::getNumber(const UnicodeString* pstr)
+int UnicodeTools::getNumber(const UnicodeString* pstr, int ofs, int len)
 {
   int r = 1, num = 0;
   if (pstr == nullptr) {
     return -1;
   }
-  for (int i = pstr->length() - 1; i >= 0; i--) {
+  if (len < 0)
+    len = pstr->length();
+  for (int i = len - 1; i >= ofs; i--) {
     if ((*pstr)[i] > '9' || (*pstr)[i] < '0') {
       return -1;
     }

--- a/src/colorer/strings/icu/UnicodeTools.cpp
+++ b/src/colorer/strings/icu/UnicodeTools.cpp
@@ -22,8 +22,8 @@ int UnicodeTools::getHexNumber(const UnicodeString* pstr, int ofs, int len)
     return -1;
   }
   if (len < 0)
-    len = pstr->length();
-  for (int i = len - 1; i >= ofs; i--) {
+    len = pstr->length() - ofs;
+  for (int i = ofs + len - 1; i >= ofs; i--) {
     int d = getHex((*pstr)[i]);
     if (d == -1) {
       return -1;
@@ -41,8 +41,8 @@ int UnicodeTools::getNumber(const UnicodeString* pstr, int ofs, int len)
     return -1;
   }
   if (len < 0)
-    len = pstr->length();
-  for (int i = len - 1; i >= ofs; i--) {
+    len = pstr->length() - ofs;
+  for (int i = ofs + len - 1; i >= ofs; i--) {
     if ((*pstr)[i] > '9' || (*pstr)[i] < '0') {
       return -1;
     }

--- a/src/colorer/strings/icu/UnicodeTools.h
+++ b/src/colorer/strings/icu/UnicodeTools.h
@@ -7,8 +7,8 @@ class UnicodeTools
 {
  public:
   static int getHex(UChar c);
-  static int getHexNumber(const UnicodeString* pstr);
-  static int getNumber(const UnicodeString* pstr);
+  static int getHexNumber(const UnicodeString* pstr, int ofs = 0, int len = -1);
+  static int getNumber(const UnicodeString* pstr, int ofs = 0, int len = -1);
 
   /** \\x{2028} \\x23 \\c  - into wchar
   @param str String to parse Escape sequence.

--- a/src/colorer/strings/icu/common_icu.h
+++ b/src/colorer/strings/icu/common_icu.h
@@ -12,5 +12,6 @@ constexpr UChar BAD_WCHAR = 0xFFFF;
 
 // system dependent byte
 using byte = unsigned char;
+using wchar = UChar;
 
 #endif  // COLORER_COMMON_ICU_H

--- a/src/colorer/strings/legacy/BitArray.cpp
+++ b/src/colorer/strings/legacy/BitArray.cpp
@@ -1,9 +1,7 @@
 #include <memory.h>
 #include <colorer/strings/legacy/BitArray.h>
 
-BitArray::BitArray()
-{
-}
+BitArray::BitArray() = default;
 
 BitArray::~BitArray()
 {

--- a/src/colorer/strings/legacy/BitArray.cpp
+++ b/src/colorer/strings/legacy/BitArray.cpp
@@ -13,6 +13,14 @@ BitArray::~BitArray()
   if (array && size_t(array) != 1) delete[] array;
 }
 
+void BitArray::clearAll()
+{
+  if (array && size_t(array) != 1) {
+    delete[] array;
+  }
+  array = nullptr;
+}
+
 void BitArray::createArray(bool set)
 {
   array = new int[size];
@@ -137,12 +145,3 @@ void BitArray::clearBitArray(char* bits, int _size)
   for (int i = 0; i < _size && i < this->size * 4; i++)
     ((char*)array)[i] &= ~bits[i];
 }
-
-bool BitArray::getBit(int pos)
-{
-  if (!array) return false;
-  if (size_t(array) == 1) return true;
-  return (array[pos >> 5] & (1 << (pos & 0x1f))) != 0;
-}
-
-

--- a/src/colorer/strings/legacy/BitArray.cpp
+++ b/src/colorer/strings/legacy/BitArray.cpp
@@ -1,16 +1,21 @@
 #include <memory.h>
 #include <colorer/strings/legacy/BitArray.h>
 
-BitArray::BitArray(int _size)
+BitArray::BitArray()
 {
-  array = nullptr;
-  this->size = _size / 8 / 4 + 1;
-  if (_size % 8 == 0 && _size / 8 % 4 == 0) this->size--;
 }
 
 BitArray::~BitArray()
 {
   if (array && size_t(array) != 1) delete[] array;
+}
+
+void BitArray::setAll()
+{
+  if (array && size_t(array) != 1) {
+    delete[] array;
+  }
+  array = (Element*)1;
 }
 
 void BitArray::clearAll()
@@ -23,45 +28,45 @@ void BitArray::clearAll()
 
 void BitArray::createArray(bool set)
 {
-  array = new int[size];
-  memset(array, set ? 0xFF : 0, size * sizeof(int));
+  array = new Element[ELEMENTS];
+  memset(array, set ? 0xFF : 0, ELEMENTS * sizeof(Element));
 }
 
 void BitArray::setBit(int pos)
 {
   if (!array) createArray();
   if (size_t(array) == 1) return;
-  array[pos >> 5] |= 1 << (pos & 0x1f);
+  array[pos >> SHIFT] |= 1 << (pos & MASK);
 }
 
 void BitArray::clearBit(int pos)
 {
   if (!array) return;
   if (size_t(array) == 1) createArray(true);
-  array[pos >> 5] &= ~(1 << (pos & 0x1f));
+  array[pos >> SHIFT] &= ~(1 << (pos & MASK));
 }
 
 void BitArray::addRange(int s, int e)
 {
   if (size_t(array) == 1) return;
   if (!array) createArray();
-  int cs = s >> 5;
-  if (s & 0x1f) {
-    int fillbytes = 0xFFFFFFFF << (s & 0x1f);
-    if ((e >> 5) == (s >> 5)) fillbytes &= 0xFFFFFFFF >> (0x1F - (e & 0x1F));
+  int cs = s >> SHIFT;
+  if (s & MASK) {
+    Element fillbytes = Element(-1) << (s & MASK);
+    if ((e >> SHIFT) == (s >> SHIFT)) fillbytes &= Element(-1) >> (MASK - (e & MASK));
     array[cs] |= fillbytes;
     cs++;
   }
-  int ce = e >> 5;
-  if (s >> 5 != ce && (e & 0x1f) != 0x1f) {
-    array[ce] |= 0xFFFFFFFF >> (0x1F - (e & 0x1F));
+  int ce = e >> SHIFT;
+  if (s >> SHIFT != ce && (e & MASK) != MASK) {
+    array[ce] |= Element(-1) >> (MASK - (e & MASK));
     ce--;
   }
   for (int idx = cs; idx <= ce; idx++)
-    array[idx] = 0xFFFFFFFF;
-  if (cs == 0 && ce == size - 1) {
+    array[idx] = Element(-1);
+  if (cs == 0 && ce == ELEMENTS - 1) {
     delete[] array;
-    array = (int*)1;
+    array = (Element*)1;
   }
 }
 
@@ -69,40 +74,40 @@ void BitArray::clearRange(int s, int e)
 {
   if (!array) return;
   if (size_t(array) == 1) createArray(true);
-  int cs = s >> 5;
-  if (s & 0x1f) {
-    int fillbytes = 0xFFFFFFFF << (s & 0x1f);
-    if ((e & 0x1F) == (s & 0x1F)) fillbytes &= 0xFFFFFFFF >> (0x1F - (e & 0x1F));
+  int cs = s >> SHIFT;
+  if (s & MASK) {
+    Element fillbytes = Element(-1) << (s & MASK);
+    if ((e & MASK) == (s & MASK)) fillbytes &= Element(-1) >> (MASK - (e & MASK));
     array[cs] &= ~fillbytes;
     cs++;
   }
-  int ce = e >> 5;
-  if (s >> 5 != ce && (e & 0x1f) != 0x1f) {
-    array[ce] &= ~(0xFFFFFFFF >> (0x1F - (e & 0x1F)));
+  int ce = e >> SHIFT;
+  if (s >> SHIFT != ce && (e & MASK) != MASK) {
+    array[ce] &= ~(Element(-1) >> (MASK - (e & MASK)));
     ce--;
   }
   for (int idx = cs; idx <= ce; idx++)
     array[idx] = 0x0;
-  if (cs == 0 && ce == size - 1) {
+  if (cs == 0 && ce == ELEMENTS - 1) {
     delete[] array;
     array = nullptr;
   }
 }
-void BitArray::addBitArray(BitArray* ba)
+void BitArray::addBitArray(const BitArray* ba)
 {
   if (size_t(array) == 1) return;
   if (!ba || !ba->array) return;
   if (size_t(ba->array) == 1) {
     delete[] array;
-    array = (int*)1;
+    array = (Element*)1;
     return;
   }
   if (!array) createArray();
-  for (int i = 0; i < size; i++)
+  for (int i = 0; i < ELEMENTS; i++)
     array[i] |= ba->array[i];
 }
 
-void BitArray::clearBitArray(BitArray* ba)
+void BitArray::clearBitArray(const BitArray* ba)
 {
   if (array == nullptr) return;
   if (ba == nullptr || ba->array == nullptr) return;
@@ -112,11 +117,11 @@ void BitArray::clearBitArray(BitArray* ba)
     array = nullptr;
     return;
   }
-  for (int i = 0; i < size; i++)
+  for (int i = 0; i < ELEMENTS; i++)
     array[i] &= ~ba->array[i];
 }
 
-void BitArray::intersectBitArray(BitArray* ba)
+void BitArray::intersectBitArray(const BitArray* ba)
 {
   if (array == nullptr) return;
   if (ba == nullptr || ba->array == nullptr) {
@@ -126,7 +131,7 @@ void BitArray::intersectBitArray(BitArray* ba)
   }
   if (size_t(ba->array) == 1) return;
   if (size_t(array) == 1) createArray(true);
-  for (int i = 0; i < size; i++)
+  for (int i = 0; i < ELEMENTS; i++)
     array[i] &= ba->array[i];
 }
 
@@ -134,7 +139,7 @@ void BitArray::addBitArray(char* bits, int _size)
 {
   if (size_t(array) == 1) return;
   if (!array) createArray();
-  for (int i = 0; i < _size && i < this->size * 4; i++)
+  for (int i = 0; i < _size && i < int(ELEMENTS * sizeof(Element)); i++)
     ((char*)array)[i] |= bits[i];
 }
 
@@ -142,6 +147,6 @@ void BitArray::clearBitArray(char* bits, int _size)
 {
   if (!array) return;
   if (size_t(array) == 1) createArray(true);
-  for (int i = 0; i < _size && i < this->size * 4; i++)
+  for (int i = 0; i < _size && i < int(ELEMENTS * sizeof(Element)); i++)
     ((char*)array)[i] &= ~bits[i];
 }

--- a/src/colorer/strings/legacy/BitArray.h
+++ b/src/colorer/strings/legacy/BitArray.h
@@ -14,6 +14,7 @@ public:
   BitArray(int size = 256);
   ~BitArray();
 
+  void clearAll();
   /** Sets bit at position @c pos */
   void setBit(int pos);
   /** Clears bit at position @c pos */
@@ -36,7 +37,12 @@ public:
   /** Clears bit array from the passed byte stream. */
   void clearBitArray(char*, int);
   /** Returns bit value at position @c pos. */
-  bool getBit(int pos);
+  inline bool getBit(int pos) const
+  {
+    if (!array) return false;
+    if (size_t(array) == 1) return true;
+    return (array[pos >> 5] & (1 << (pos & 0x1f))) != 0;
+  }
 
 #define CNAME "BitArray"
 

--- a/src/colorer/strings/legacy/BitArray.h
+++ b/src/colorer/strings/legacy/BitArray.h
@@ -8,12 +8,27 @@
 */
 class BitArray
 {
+  typedef unsigned int Element;
+  enum
+  {
+    ELEMENTS = (256 / 8 / 4),
+    SHIFT = 5,
+    MASK = 0x1f
+  };
+
+  Element* array{nullptr};
+  void createArray(bool set = false);
+
+  BitArray(const BitArray&) = delete;
+  BitArray&operator =(const BitArray&) = delete;
+
 public:
   /** Creates bit array with specified number of stored bitfields.
   */
-  BitArray(int size = 256);
+  BitArray();
   ~BitArray();
 
+  void setAll();
   void clearAll();
   /** Sets bit at position @c pos */
   void setBit(int pos);
@@ -25,13 +40,13 @@ public:
   void clearRange(int s, int e);
   /** Sets bits to 1, whose corresponding values
       in passed bit array are also 1 (bitwize OR) */
-  void addBitArray(BitArray*);
+  void addBitArray(const BitArray*);
   /** Sets bits to 0, whose corresponding values
       in passed bit array are also 1 */
-  void clearBitArray(BitArray*);
+  void clearBitArray(const BitArray*);
   /** Makes intersection of current and
       the passed bit array (bitwize AND) */
-  void intersectBitArray(BitArray*);
+  void intersectBitArray(const BitArray*);
   /** Adds bit array from the passed byte stream. */
   void addBitArray(char*, int);
   /** Clears bit array from the passed byte stream. */
@@ -45,11 +60,6 @@ public:
   }
 
 #define CNAME "BitArray"
-
-private:
-  int* array;
-  int size;
-  void createArray(bool set = false);
 };
 
 #endif

--- a/src/colorer/strings/legacy/Character.cpp
+++ b/src/colorer/strings/legacy/Character.cpp
@@ -59,9 +59,19 @@ bool Character::isTitleCase(wchar c)
   return CHAR_CATEGORY(CHAR_PROP(c)) == CHAR_CATEGORY_Lt;
 }
 
-
+/*
+Breakdown of ASCII Categories
+  Lu (Uppercase Letters): ASCII codes 65 to 90 (A through Z)
+  Ll (Lowercase Letters): ASCII codes 97 to 122 (a through z)
+  Lt (Titlecase Letters): None (applicable to specific multi-character Unicode digraphs like ǅ)
+  Lm (Modifier Letters): None in standard ASCII (e.g., spacing macrons or modifier apostrophes exist in extended Unicode blocks, though ASCII backtick ` (96) and single quote ' (39) are classified as punctuation/symbols, not Lm)
+  Lo (Other Letters): None (reserved for un-cased alphabets, ideographs, or syllabics like Hangul or Chinese characters found outside standard ASCII)
+*/
 bool Character::isLetter(wchar c)
 {
+  if (unsigned(c) <= 0x7f) {
+    return (c >= L'A' && c <= L'Z') || (c >= L'a' && c <= L'z');
+  }
   unsigned long c1 = CHAR_CATEGORY(CHAR_PROP(c));
   return ((((1 << CHAR_CATEGORY_Lu) |
             (1 << CHAR_CATEGORY_Ll) |
@@ -73,6 +83,9 @@ bool Character::isLetter(wchar c)
 
 bool Character::isLetterOrDigit(wchar c)
 {
+  if (unsigned(c) <= 0x7f) {
+    return (c >= L'A' && c <= L'Z') || (c >= L'a' && c <= L'z') || (c >= L'0' && c <= L'9');
+  }
   unsigned long c1 = CHAR_CATEGORY(CHAR_PROP(c));
   return ((((1 << CHAR_CATEGORY_Lu) |
             (1 << CHAR_CATEGORY_Ll) |
@@ -85,6 +98,9 @@ bool Character::isLetterOrDigit(wchar c)
 
 bool Character::isDigit(wchar c)
 {
+  if (unsigned(c) <= 0x7f) {
+    return (c >= L'0' && c <= L'9');
+  }
   return CHAR_CATEGORY(CHAR_PROP(c)) == CHAR_CATEGORY_Nd;
 }
 

--- a/src/colorer/strings/legacy/Character.cpp
+++ b/src/colorer/strings/legacy/Character.cpp
@@ -81,10 +81,10 @@ bool Character::isLetter(wchar c)
            ) >> c1) & 1) != 0;
 }
 
-bool Character::isLetterOrDigit(wchar c)
+bool Character::isLetterOrDigitOrUnderscore(wchar c)
 {
   if (unsigned(c) <= 0x7f) {
-    return (c >= L'A' && c <= L'Z') || (c >= L'a' && c <= L'z') || (c >= L'0' && c <= L'9');
+    return (c >= L'A' && c <= L'Z') || (c >= L'a' && c <= L'z') || (c >= L'0' && c <= L'9') || c == '_';
   }
   unsigned long c1 = CHAR_CATEGORY(CHAR_PROP(c));
   return ((((1 << CHAR_CATEGORY_Lu) |

--- a/src/colorer/strings/legacy/Character.cpp
+++ b/src/colorer/strings/legacy/Character.cpp
@@ -5,6 +5,12 @@
 
 wchar Character::toLowerCase(wchar c)
 {
+  if (unsigned(c) <= 0x7f) {
+    if (c >= L'A' && c <= L'Z') {
+      return c + L'a' - L'A';
+    }
+    return c;
+  }
   unsigned long c1 = CHAR_PROP(c);
   if (CHAR_CATEGORY(c1) == CHAR_CATEGORY_Ll) return c;
   if (CHAR_CATEGORY(c1) == CHAR_CATEGORY_Lt) return c + 1;
@@ -13,6 +19,12 @@ wchar Character::toLowerCase(wchar c)
 
 wchar Character::toUpperCase(wchar c)
 {
+  if (unsigned(c) <= 0x7f) {
+    if (c >= L'a' && c <= L'z') {
+      return c - (L'a' - L'A');
+    }
+    return c;
+  }
   unsigned long c1 = CHAR_PROP(c);
   if (CHAR_CATEGORY(c1) == CHAR_CATEGORY_Lu) return c;
   if (CHAR_CATEGORY(c1) == CHAR_CATEGORY_Lt) return c - 1;

--- a/src/colorer/strings/legacy/Character.h
+++ b/src/colorer/strings/legacy/Character.h
@@ -35,7 +35,7 @@ public:
   static bool isUpperCase(wchar c);
   static bool isTitleCase(wchar c);
   static bool isLetter(wchar c);
-  static bool isLetterOrDigit(wchar c);
+  static bool isLetterOrDigitOrUnderscore(wchar c);
   static bool isDigit(wchar c);
   static bool isAssigned(wchar c);
   static bool isSpaceChar(wchar c);

--- a/src/colorer/strings/legacy/CharacterClass.cpp
+++ b/src/colorer/strings/legacy/CharacterClass.cpp
@@ -9,8 +9,7 @@
 
 CharacterClass::CharacterClass()
 {
-  infoIndex = new BitArray*[256];
-  memset(infoIndex, 0, 256 * sizeof(*infoIndex));
+  infoIndex = new BitArray[256];
 }
 
 CharacterClass::~CharacterClass()
@@ -192,12 +191,7 @@ std::unique_ptr<CharacterClass> CharacterClass::createCharClass(const UnicodeStr
 
 void CharacterClass::addChar(wchar c)
 {
-  BitArray* tablePos = infoIndex[(c >> 8) & 0xFF];
-  if (!tablePos) {
-    tablePos = new BitArray();
-    infoIndex[(c >> 8) & 0xFF] = tablePos;
-  }
-  tablePos->setBit(c & 0xFF);
+  infoIndex[(c >> 8) & 0xFF].setBit(c & 0xFF);
 }
 
 void CharacterClass::add(wchar c)
@@ -207,24 +201,20 @@ void CharacterClass::add(wchar c)
 
 void CharacterClass::clearChar(wchar c)
 {
-  BitArray* tablePos = infoIndex[(c >> 8) & 0xFF];
-  if (!tablePos) return;
-  tablePos->clearBit(c & 0xFF);
+  infoIndex[(c >> 8) & 0xFF].clearBit(c & 0xFF);
 }
 
 void CharacterClass::addRange(wchar s, wchar e)
 {
   for (int ti = (int)(s >> 8) & 0xFF; ti <= (int)((e >> 8) & 0xFF); ti++) {
-    if (!infoIndex[ti]) infoIndex[ti] = new BitArray();
-    infoIndex[ti]->addRange((ti == (int)(s >> 8)) ? s & 0xFF : 0, (ti == (int)(e >> 8)) ? e & 0xFF : 0xFF);
+    infoIndex[ti].addRange((ti == (int)(s >> 8)) ? s & 0xFF : 0, (ti == (int)(e >> 8)) ? e & 0xFF : 0xFF);
   }
 }
 
 void CharacterClass::clearRange(wchar s, wchar e)
 {
   for (int ti = (s >> 8) & 0xFF; ti <= (int)((e >> 8) & 0xFF); ti++) {
-    if (!infoIndex[ti]) infoIndex[ti] = new BitArray();
-    infoIndex[ti]->clearRange(ti == (int)(s >> 8) ? s & 0xFF : 0, ti == (int)(e >> 8) ? e & 0xFF : 0xFF);
+    infoIndex[ti].clearRange(ti == (int)(s >> 8) ? s & 0xFF : 0, ti == (int)(e >> 8) ? e & 0xFF : 0xFF);
   }
 }
 
@@ -234,12 +224,7 @@ void CharacterClass::addCategory(ECharCategory cat)
   for (int i = 0; i < 0x100; i++) {
     unsigned short pos = arr_idxCharCategoryIdx[(int(cat) - 1) * 0x100 + i];
     if (!pos) continue;
-    BitArray* tablePos = infoIndex[i];
-    if (!tablePos) {
-      tablePos = new BitArray();
-      infoIndex[i] = tablePos;
-    }
-    tablePos->addBitArray((char*)(arr_idxCharCategory + pos), 8 * 4);
+    infoIndex[i].addBitArray((char*)(arr_idxCharCategory + pos), 8 * 4);
   }
 }
 
@@ -263,12 +248,7 @@ void CharacterClass::clearCategory(ECharCategory cat)
   for (int i = 0; i < 0x100; i++) {
     unsigned short pos = arr_idxCharCategoryIdx[(int(cat) - 1) * 0x100 + i];
     if (!pos) continue;
-    BitArray* tablePos = infoIndex[i];
-    if (!tablePos) {
-      tablePos = new BitArray();
-      infoIndex[i] = tablePos;
-    }
-    tablePos->clearBitArray((char*)(arr_idxCharCategory + pos), 8 * 4);
+    infoIndex[i].clearBitArray((char*)(arr_idxCharCategory + pos), 8 * 4);
   }
 }
 
@@ -289,48 +269,39 @@ void CharacterClass::clearCategory(const char* cat)
 void CharacterClass::addClass(const CharacterClass &cclass)
 {
   for (int p = 0; p < 256; p++) {
-    if (!infoIndex[p]) infoIndex[p] = new BitArray();
-    infoIndex[p]->addBitArray(cclass.infoIndex[p]);
+    infoIndex[p].addBitArray(&cclass.infoIndex[p]);
   }
 }
 
 void CharacterClass::intersectClass(const CharacterClass &cclass)
 {
   for (int p = 0; p < 256; p++) {
-    if (infoIndex[p])
-      infoIndex[p]->intersectBitArray(cclass.infoIndex[p]);
+    infoIndex[p].intersectBitArray(&cclass.infoIndex[p]);
   }
 }
 
 void CharacterClass::clearClass(const CharacterClass &cclass)
 {
   for (int p = 0; p < 256; p++)
-    if (infoIndex[p])
-      infoIndex[p]->clearBitArray(cclass.infoIndex[p]);
+    infoIndex[p].clearBitArray(&cclass.infoIndex[p]);
 }
 
 void CharacterClass::clear()
 {
   for (int i = 0; i < 256; i++)
-    if (infoIndex[i]) {
-      delete infoIndex[i];
-      infoIndex[i] = nullptr;
-    }
+    infoIndex[i].clearAll();
 }
 
 void CharacterClass::fill()
 {
   for (int i = 0; i < 256; i++) {
-    if (!infoIndex[i]) infoIndex[i] = new BitArray();
-    infoIndex[i]->addRange(0, 0xFF);
+    infoIndex[i].addRange(0, 0xFF);
   }
 }
 
 bool CharacterClass::inClass(wchar c) const
 {
-  BitArray* tablePos = infoIndex[(c >> 8) & 0xFF];
-  if (!tablePos) return false;
-  return tablePos->getBit(c & 0xFF);
+  return infoIndex[(c >> 8) & 0xFF].getBit(c & 0xFF);
 }
 
 bool CharacterClass::contains(wchar c) const
@@ -338,4 +309,7 @@ bool CharacterClass::contains(wchar c) const
   return inClass(c);
 }
 
-void CharacterClass::freeze() {}
+void CharacterClass::freeze()
+{
+}
+

--- a/src/colorer/strings/legacy/CharacterClass.cpp
+++ b/src/colorer/strings/legacy/CharacterClass.cpp
@@ -9,13 +9,10 @@
 
 CharacterClass::CharacterClass()
 {
-  infoIndex = new BitArray[256];
 }
 
 CharacterClass::~CharacterClass()
 {
-  clear();
-  delete[] infoIndex;
 }
 
 /**
@@ -295,18 +292,8 @@ void CharacterClass::clear()
 void CharacterClass::fill()
 {
   for (int i = 0; i < 256; i++) {
-    infoIndex[i].addRange(0, 0xFF);
+    infoIndex[i].setAll();
   }
-}
-
-bool CharacterClass::inClass(wchar c) const
-{
-  return infoIndex[(c >> 8) & 0xFF].getBit(c & 0xFF);
-}
-
-bool CharacterClass::contains(wchar c) const
-{
-  return inClass(c);
 }
 
 void CharacterClass::freeze()

--- a/src/colorer/strings/legacy/CharacterClass.cpp
+++ b/src/colorer/strings/legacy/CharacterClass.cpp
@@ -299,4 +299,3 @@ void CharacterClass::fill()
 void CharacterClass::freeze()
 {
 }
-

--- a/src/colorer/strings/legacy/CharacterClass.cpp
+++ b/src/colorer/strings/legacy/CharacterClass.cpp
@@ -7,13 +7,9 @@
 /// macro - number of elements in array
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof(*(a)))
 
-CharacterClass::CharacterClass()
-{
-}
+CharacterClass::CharacterClass() = default;
 
-CharacterClass::~CharacterClass()
-{
-}
+CharacterClass::~CharacterClass() = default;
 
 /**
   Creates CharacterClass object from regexp character class syntax.

--- a/src/colorer/strings/legacy/CharacterClass.h
+++ b/src/colorer/strings/legacy/CharacterClass.h
@@ -16,7 +16,7 @@
 class CharacterClass
 {
 private:
-  BitArray** infoIndex;
+  BitArray* infoIndex;
 public:
   CharacterClass();
   ~CharacterClass();

--- a/src/colorer/strings/legacy/CharacterClass.h
+++ b/src/colorer/strings/legacy/CharacterClass.h
@@ -16,7 +16,7 @@
 class CharacterClass
 {
 private:
-  BitArray* infoIndex;
+  BitArray infoIndex[256];
 public:
   CharacterClass();
   ~CharacterClass();
@@ -42,8 +42,15 @@ public:
   void clear();
   void fill();
 
-  bool inClass(wchar c) const;
-  bool contains(wchar c) const;
+  inline bool inClass(wchar c) const
+  {
+    return infoIndex[(c >> 8) & 0xFF].getBit(c & 0xFF);
+  }
+
+  inline bool contains(wchar c) const
+  {
+    return inClass(c);
+  }
 
   void freeze();
 

--- a/src/colorer/strings/legacy/UStr.cpp
+++ b/src/colorer/strings/legacy/UStr.cpp
@@ -33,6 +33,11 @@ int8_t UStr::caseCompare(const UnicodeString& str1, const UnicodeString& str2)
   return str1.caseCompare(str2);
 }
 
+int8_t UStr::caseCompare(const UnicodeString& str1, int str1_pos, int str1_len, const UnicodeString& str2)
+{
+  return str1.caseCompare(str1_pos, str1_len, str2);
+}
+
 UnicodeString UStr::to_unistr(int number)
 {
   return {number};

--- a/src/colorer/strings/legacy/UStr.h
+++ b/src/colorer/strings/legacy/UStr.h
@@ -18,8 +18,8 @@ class UStr
   [[nodiscard]] static std::wstring to_stdwstr(const UnicodeString& str);
 
   static std::unique_ptr<CharacterClass> createCharClass(const UnicodeString& ccs, int pos, int* retPos, bool ignore_case);
-
   static int8_t caseCompare(const UnicodeString& str1, const UnicodeString& str2);
+  static int8_t caseCompare(const UnicodeString& str1, int str1_pos, int str1_len, const UnicodeString& str2);
   static bool HexToUInt(const UnicodeString& str_hex, unsigned int* result);
   static int32_t indexOfIgnoreCase(const UnicodeString& str1, const UnicodeString& str2, int32_t pos = 0);
 };

--- a/src/colorer/strings/legacy/UnicodeString.cpp
+++ b/src/colorer/strings/legacy/UnicodeString.cpp
@@ -96,6 +96,14 @@ UnicodeString::UnicodeString(int no)
   construct(&dtext, 0, npos);
 }
 
+UnicodeString& UnicodeString::toLower()
+{
+  for (auto i = length(); i--;) {
+    wstr[i] = Character::toLowerCase(wstr[i]);
+  }
+  return *this;
+}
+
 UnicodeString& UnicodeString::trim()
 {
   int32_t left;

--- a/src/colorer/strings/legacy/UnicodeString.cpp
+++ b/src/colorer/strings/legacy/UnicodeString.cpp
@@ -96,11 +96,6 @@ UnicodeString::UnicodeString(int no)
   construct(&dtext, 0, npos);
 }
 
-int32_t UnicodeString::length() const
-{
-  return len;
-}
-
 UnicodeString& UnicodeString::trim()
 {
   int32_t left;
@@ -120,11 +115,6 @@ UnicodeString& UnicodeString::trim()
   len = newLength;
   alloc = newLength;
   return *this;
-}
-
-wchar UnicodeString::operator[](int32_t i) const
-{
-  return wstr[i];
 }
 
 UnicodeString::UnicodeString(UnicodeString&& cstring) noexcept
@@ -211,22 +201,21 @@ UnicodeString& UnicodeString::operator=(UnicodeString const& cstring)
   return *this;
 }
 
-int8_t UnicodeString::compare(const UnicodeString& str) const
+int8_t UnicodeString::compare(int sp, int sl, const UnicodeString& str) const
 {
+  auto l = std::min(str.length(), sl);
   int32_t i;
-  auto sl = str.length();
-  auto l = length();
-  for (i = 0; i < sl && i < l; i++) {
-    int cmp = str[i] - this->wstr[i];
+  for (i = 0; i < l; i++) {
+    int cmp = (str[i]) - ((*this)[i + sp]);
     if (cmp > 0)
       return -1;
     if (cmp < 0)
       return 1;
   }
   if (i < sl)
-    return -1;
-  if (i < l)
     return 1;
+  if (i < str.length())
+    return -1;
   return 0;
 }
 
@@ -268,22 +257,21 @@ bool UnicodeString::equalsIgnoreCase(const UnicodeString* str) const
   return true;
 }
 
-int8_t UnicodeString::caseCompare(const UnicodeString& str) const
+int8_t UnicodeString::caseCompare(int sp, int sl, const UnicodeString& str) const
 {
+  auto l = std::min(str.length(), sl);
   int32_t i;
-  auto sl = str.length();
-  auto l = length();
-  for (i = 0; i < sl && i < l; i++) {
-    int cmp = Character::toLowerCase(str[i]) - Character::toLowerCase((*this)[i]);
+  for (i = 0; i < l; i++) {
+    int cmp = Character::toLowerCase(str[i]) - Character::toLowerCase((*this)[i + sp]);
     if (cmp > 0)
       return -1;
     if (cmp < 0)
       return 1;
   }
   if (i < sl)
-    return -1;
-  if (i < l)
     return 1;
+  if (i < str.length())
+    return -1;
   return 0;
 }
 
@@ -476,11 +464,6 @@ UnicodeString& UnicodeString::findAndReplace(const UnicodeString& pattern, const
 
   *this = *newname;
   return *this;
-}
-
-bool UnicodeString::isEmpty() const
-{
-  return len == 0;
 }
 
 UnicodeString::UnicodeString(const UnicodeString& cstring)

--- a/src/colorer/strings/legacy/UnicodeString.h
+++ b/src/colorer/strings/legacy/UnicodeString.h
@@ -40,12 +40,18 @@ class UnicodeString
 
   UnicodeString& append(const UnicodeString& string);
   UnicodeString& append(const UnicodeString& string, int32_t start, int32_t maxlen);
-  /** Compares two strings.
-    @return -1 if this < str;
-            0  if this == str;
-            1  if this > str;
+  /** Compares this[sp, sp + sl] against  whole another str.
+    @return -1 if this[sp, sp + sl] < str;
+            0  if this[sp, sp + sl] == str;
+            1  if this[sp, sp + sl] > str;
   */
-  int8_t compare(const UnicodeString& str) const;
+  int8_t compare(int sp, int sl, const UnicodeString& str) const;
+
+  /** Same compare but as as whole string */
+  int8_t compare(const UnicodeString& str) const
+  {
+    return compare(0, length(), str);
+  }
 
   ~UnicodeString();
 
@@ -73,18 +79,36 @@ class UnicodeString
   bool equalsIgnoreCase(const UnicodeString* str) const;
 
 
-  /** Compares two strings ignoring case
-    @return -1 if this < str;
-            0  if this == str;
-            1  if this > str;
+  /** Compares ignoring case this[sp, sp + sl] against whole another str
+    @return -1 if this[sp, sp + sl] < str;
+            0  if this[sp, sp + sl] == str;
+            1  if this[sp, sp + sl] > str;
   */
-  int8_t caseCompare(const UnicodeString& str) const;
+  int8_t caseCompare(int sp, int sl, const UnicodeString& str) const;
+
+  /** Same ignoring case compare but as as whole string */
+  inline int8_t caseCompare(const UnicodeString& str) const
+  {
+    return caseCompare(0, length(), str);
+  }
 
   bool operator<(const UnicodeString & text) const;
 
-  wchar operator[](int32_t i) const;
+  inline wchar operator[](int32_t i) const
+  {
+    return wstr[i];
+  }
+
   /** String length in unicode characters */
-  int32_t length() const;
+  inline int32_t length() const
+  {
+    return len;
+  }
+
+  inline bool isEmpty() const
+  {
+    return len == 0;
+  }
 
   UnicodeString& trim();
 
@@ -124,7 +148,6 @@ class UnicodeString
   /** Returns string content in internally supported character array */
   const char* getChars(int encoding = -1) const;
 
-  bool isEmpty() const;
   static const int32_t npos = -1;
 
  private:

--- a/src/colorer/strings/legacy/UnicodeString.h
+++ b/src/colorer/strings/legacy/UnicodeString.h
@@ -111,6 +111,7 @@ class UnicodeString
   }
 
   UnicodeString& trim();
+  UnicodeString& toLower();
 
   /** Searches first index of substring @c str, starting from @c pos */
   int32_t indexOf(const UnicodeString& str, int32_t pos = 0) const;

--- a/src/colorer/strings/legacy/UnicodeTools.cpp
+++ b/src/colorer/strings/legacy/UnicodeTools.cpp
@@ -19,13 +19,17 @@ int UnicodeTools::getNumber(const UnicodeString* pstr)
 
 int UnicodeTools::getHex(wchar c)
 {
-  c = Character::toLowerCase(c);
-  c -= '0';
-  if (c >= 'a' - '0' && c <= 'f' - '0')
-    c -= 0x27;
-  else if (c > 9)
-    return -1;
-  return c;
+  if (c >= '0' && c <= '9') {
+    return c - '0';
+  }
+//  c = Character::toLowerCase(c);
+  if (c >= 'a' && c <= 'f') {
+    return 10 + (c - 'a');
+  }
+  if (c >= 'A' && c <= 'F') {
+    return 10 + (c - 'A');
+  }
+  return -1;
 }
 
 int UnicodeTools::getHexNumber(const UnicodeString* pstr)

--- a/src/colorer/strings/legacy/UnicodeTools.cpp
+++ b/src/colorer/strings/legacy/UnicodeTools.cpp
@@ -2,13 +2,15 @@
 #include "colorer/strings/legacy/UnicodeTools.h"
 #include "colorer/strings/legacy/UnicodeString.h"
 
-int UnicodeTools::getNumber(const UnicodeString* pstr)
+int UnicodeTools::getNumber(const UnicodeString* pstr, int ofs, int len)
 {
   int r = 1;
   int num = 0;
   if (pstr == nullptr)
     return -1;
-  for (int i = pstr->length() - 1; i >= 0; i--) {
+  if (len < 0)
+    len = pstr->length();
+  for (int i = len - 1; i >= ofs; i--) {
     if ((*pstr)[i] > '9' || (*pstr)[i] < '0')
       return -1;
     num += ((*pstr)[i] - 0x30) * r;
@@ -32,12 +34,14 @@ int UnicodeTools::getHex(wchar c)
   return -1;
 }
 
-int UnicodeTools::getHexNumber(const UnicodeString* pstr)
+int UnicodeTools::getHexNumber(const UnicodeString* pstr, int ofs, int len)
 {
   int r = 0, num = 0;
   if (pstr == nullptr)
     return -1;
-  for (int i = (*pstr).length() - 1; i >= 0; i--) {
+  if (len < 0)
+    len = pstr->length();
+  for (int i = len - 1; i >= ofs; i--) {
     int d = getHex((*pstr)[i]);
     if (d == -1)
       return -1;

--- a/src/colorer/strings/legacy/UnicodeTools.cpp
+++ b/src/colorer/strings/legacy/UnicodeTools.cpp
@@ -9,8 +9,8 @@ int UnicodeTools::getNumber(const UnicodeString* pstr, int ofs, int len)
   if (pstr == nullptr)
     return -1;
   if (len < 0)
-    len = pstr->length();
-  for (int i = len - 1; i >= ofs; i--) {
+    len = pstr->length() - ofs;
+  for (int i = ofs + len - 1; i >= ofs; i--) {
     if ((*pstr)[i] > '9' || (*pstr)[i] < '0')
       return -1;
     num += ((*pstr)[i] - 0x30) * r;
@@ -40,8 +40,8 @@ int UnicodeTools::getHexNumber(const UnicodeString* pstr, int ofs, int len)
   if (pstr == nullptr)
     return -1;
   if (len < 0)
-    len = pstr->length();
-  for (int i = len - 1; i >= ofs; i--) {
+    len = pstr->length() - ofs;
+  for (int i = ofs + len - 1; i >= ofs; i--) {
     int d = getHex((*pstr)[i]);
     if (d == -1)
       return -1;

--- a/src/colorer/strings/legacy/UnicodeTools.h
+++ b/src/colorer/strings/legacy/UnicodeTools.h
@@ -13,9 +13,9 @@ class UnicodeTools
  public:
   /// sometimes need it...
 
-  static int getNumber(const UnicodeString* pstr);
+  static int getNumber(const UnicodeString* pstr, int ofs = 0, int len = -1);
   static int getHex(wchar c);
-  static int getHexNumber(const UnicodeString* pstr);
+  static int getHexNumber(const UnicodeString* pstr, int ofs = 0, int len = -1);
 
   /** For '{name}'  returns 'name'
       Removes brackets and returns new dynamic string,


### PR DESCRIPTION
перенос оптимизаций движка colorer из проекта far2l.
Сравнение разбора очнеь больших файлов для 3 языков в старой и новой версии показывает рост производительности в 5-10 раз. 
ICU версия отстает от версии с встроенными строками за счет отсутсвия части оптимизаций

  | api.php | rewritegeneric.go | sqlite3.c
-- | -- | -- | --
perftest_icu | 2.00164 | 1.23723 | 15.735
perftest_icu_new | 0.300671 | 0.133509 | 3.03882
  | 6.65724329915423 | 9.26701570680628 | 5.17799672241199
Perftest_int | 1.67212 | 1.00937 | 14.3749
Perftest_int_new | 0.23247 | 0.0999486 | 2.16898
  | 7.19284208715103 | 10.0988908298866 | 6.62749310735922

