### PR TITLE
jar cache

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ set(SRC_COLORER
     colorer/xml/XMLNode.h
     colorer/xml/XmlInputSource.cpp
     colorer/xml/XmlInputSource.h
+    colorer/xml/XmlLoadSession.h
     colorer/xml/XmlReader.cpp
     colorer/xml/XmlReader.h
 )

--- a/src/colorer/HrcLibrary.h
+++ b/src/colorer/HrcLibrary.h
@@ -7,6 +7,8 @@
 #include "colorer/common/spimpl.h"
 #include "colorer/xml/XmlInputSource.h"
 
+class XmlJarCache;
+
 /** Informs application about internal HRC parsing problems.
  */
 class HrcLibraryException : public Exception
@@ -77,6 +79,11 @@ class HrcLibrary
       @note Also loads referred type, if it is not yet loaded.
   */
   const Region* getRegion(const UnicodeString* name);
+
+  /** Zip bytes loaded by this library. ParserFactory binds it around catalog/HRD
+   * so a second factory reloads from disk instead of sharing a process-wide cache.
+   */
+  XmlJarCache& xmlJarCache();
 
  private:
   class Impl;

--- a/src/colorer/cregexp/cregexp.cpp
+++ b/src/colorer/cregexp/cregexp.cpp
@@ -1,6 +1,6 @@
 #include "colorer/cregexp/cregexp.h"
 
-std::vector<StackElem> CRegExp::RegExpStack;
+thread_local std::vector<StackElem> CRegExp::RegExpStack;
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/colorer/cregexp/cregexp.h
+++ b/src/colorer/cregexp/cregexp.h
@@ -360,7 +360,7 @@ class CRegExp
   void insert_stack(SRegInfo** re, SRegInfo** prev, int* toParse, bool* leftenter, ReAction ifTrueReturn,
                     ReAction ifFalseReturn, SRegInfo** re2, SRegInfo** prev2, int toParse2);
 
-  static std::vector<StackElem> RegExpStack;
+  static thread_local std::vector<StackElem> RegExpStack;
 
  public:
   static void clearRegExpStack();

--- a/src/colorer/parsers/HrcLibrary.cpp
+++ b/src/colorer/parsers/HrcLibrary.cpp
@@ -3,6 +3,11 @@
 
 HrcLibrary::HrcLibrary() : pimpl(spimpl::make_unique_impl<Impl>()) {}
 
+XmlJarCache& HrcLibrary::xmlJarCache()
+{
+  return pimpl->xml_jars;
+}
+
 void HrcLibrary::loadSource(XmlInputSource* is)
 {
   pimpl->loadSource(is, Impl::LoadType::FULL);

--- a/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -37,6 +37,8 @@ HrcLibrary::Impl::~Impl()
 
 void HrcLibrary::Impl::loadSource(XmlInputSource* input_source, const LoadType load_type)
 {
+  XmlLoadSession xml_session(xml_jars);
+
   if (!input_source) {
     throw HrcLibraryException("Can't open stream - 'null' is bad stream.");
   }
@@ -121,6 +123,7 @@ void HrcLibrary::Impl::loadFileType(FileType* filetype)
 
 void HrcLibrary::Impl::loadHrcSettings(const XmlInputSource& is)
 {
+  XmlLoadSession xml_session(xml_jars);
   XmlReader xml_parser(is);
   if (!xml_parser.parse()) {
     throw HrcLibraryException("Error reading " + is.getPath());

--- a/src/colorer/parsers/HrcLibraryImpl.h
+++ b/src/colorer/parsers/HrcLibraryImpl.h
@@ -7,6 +7,7 @@
 #include "colorer/parsers/SchemeImpl.h"
 #include "colorer/xml/XMLNode.h"
 #include "colorer/xml/XmlInputSource.h"
+#include "colorer/xml/XmlLoadSession.h"
 
 class FileType;
 
@@ -34,6 +35,8 @@ class HrcLibrary::Impl
   size_t getRegionCount() const;
   const Region* getRegion(unsigned int id) const;
   const Region* getRegion(const UnicodeString* name);
+
+  XmlJarCache xml_jars;
 
  protected:
   enum class QualifyNameType { QNT_DEFINE, QNT_SCHEME, QNT_ENTITY };

--- a/src/colorer/parsers/ParserFactoryImpl.cpp
+++ b/src/colorer/parsers/ParserFactoryImpl.cpp
@@ -4,6 +4,7 @@
 #include "colorer/parsers/CatalogParser.h"
 #include "colorer/parsers/HrcLibraryImpl.h"
 #include "colorer/utils/Environment.h"
+#include "colorer/xml/XmlLoadSession.h"
 #include "colorer/xml/XmlReader.h"
 
 ParserFactory::Impl::Impl()
@@ -14,11 +15,11 @@ ParserFactory::Impl::Impl()
 ParserFactory::Impl::~Impl()
 {
   delete hrc_library;
-  CRegExp::clearRegExpStack();
 }
 
 void ParserFactory::Impl::loadCatalog(const UnicodeString* catalog_path)
 {
+  XmlLoadSession xml_session(hrc_library->xmlJarCache());
   if (!catalog_path || catalog_path->isEmpty()) {
     COLORER_LOG_DEBUG("loadCatalog for empty path");
 
@@ -46,6 +47,7 @@ void ParserFactory::Impl::loadCatalog(const UnicodeString* catalog_path)
 
 void ParserFactory::Impl::loadHrcPath(const UnicodeString* location, const UnicodeString* base_path) const
 {
+  XmlLoadSession xml_session(hrc_library->xmlJarCache());
   if (!location) {
     return;
   }
@@ -110,6 +112,8 @@ void ParserFactory::Impl::loadHrdPath(const UnicodeString* location)
   if (!location) {
     return;
   }
+
+  XmlLoadSession xml_session(hrc_library->xmlJarCache());
 
   COLORER_LOG_DEBUG("start load hrd files");
   try {
@@ -294,6 +298,7 @@ std::unique_ptr<TextHRDMapper> ParserFactory::Impl::createTextMapper(const Unico
 
 void ParserFactory::Impl::fillMapper(const UnicodeString& classID, const UnicodeString* nameID, RegionMapper& mapper)
 {
+  XmlLoadSession xml_session(hrc_library->xmlJarCache());
   const UnicodeString* name_id;
   const UnicodeString name_default(HrdNameDefault);
   uUnicodeString hrd;

--- a/src/colorer/xml/XmlLoadSession.h
+++ b/src/colorer/xml/XmlLoadSession.h
@@ -1,0 +1,45 @@
+#ifndef COLORER_XMLLOADSESSION_H
+#define COLORER_XMLLOADSESSION_H
+
+#include "colorer/Common.h"
+
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+#include <memory>
+#include <unordered_map>
+#include "colorer/xml/libxml2/SharedXmlInputSource.h"
+#endif
+
+/** Per-HrcLibrary zip bytes. Not process-global: a probe ParserFactory
+ * re-reads disk instead of seeing the live instance's already-loaded jar.
+ */
+class XmlJarCache
+{
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+ public:
+  std::unordered_map<UnicodeString, std::unique_ptr<SharedXmlInputSource>> jars;
+#endif
+};
+
+/** Activates cache for XML parses on this thread until destroyed.
+ * Nested sessions restore the previous cache pointer.
+ */
+class XmlLoadSession
+{
+ public:
+  explicit XmlLoadSession(XmlJarCache& cache);
+  ~XmlLoadSession();
+
+  XmlLoadSession(const XmlLoadSession&) = delete;
+  XmlLoadSession& operator=(const XmlLoadSession&) = delete;
+
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  static XmlJarCache* active();
+#endif
+
+ private:
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache* prev {nullptr};
+#endif
+};
+
+#endif  // COLORER_XMLLOADSESSION_H

--- a/src/colorer/xml/libxml2/LibXmlReader.cpp
+++ b/src/colorer/xml/libxml2/LibXmlReader.cpp
@@ -1,12 +1,16 @@
 #include "colorer/xml/libxml2/LibXmlReader.h"
 #include <libxml/parserInternals.h>
+#include <cstdarg>
 #include <cstring>
-#include <fstream>
+#include <memory>
+#include <unordered_map>
 #include "colorer/Exception.h"
 #include "colorer/base/BaseNames.h"
 #include "colorer/utils/Environment.h"
+#include "colorer/xml/XmlLoadSession.h"
 
 #ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+#include "colorer/xml/libxml2/SharedXmlInputSource.h"
 #include "colorer/zip/MemoryFile.h"
 #endif
 
@@ -14,19 +18,71 @@
 #define strdup(p) _strdup(p)
 #endif
 
-uUnicodeString LibXmlReader::current_file = nullptr;
-bool LibXmlReader::is_first_call = false;
+namespace {
+
+struct XmlLoadContext
+{
+  UnicodeString current_file;
+  bool is_first_call = true;
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  std::unordered_map<UnicodeString, std::unique_ptr<SharedXmlInputSource>> jars;
+#endif
+};
+
+XmlLoadContext* loadContext(xmlParserCtxtPtr ctxt)
+{
+  if (ctxt == nullptr) {
+    return nullptr;
+  }
+  return static_cast<XmlLoadContext*>(ctxt->_private);
+}
+
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+thread_local XmlJarCache* g_active_jars = nullptr;
+#endif
+
+}  // namespace
+
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+XmlJarCache* XmlLoadSession::active()
+{
+  return g_active_jars;
+}
+#endif
+
+XmlLoadSession::XmlLoadSession(XmlJarCache& cache)
+{
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  prev = g_active_jars;
+  g_active_jars = &cache;
+#else
+  (void) cache;
+#endif
+}
+
+XmlLoadSession::~XmlLoadSession()
+{
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  g_active_jars = prev;
+#endif
+}
 
 LibXmlReader::LibXmlReader(const UnicodeString& source_file)
 {
-  xmlSetExternalEntityLoader(xmlMyExternalEntityLoader);
-  xmlSetGenericErrorFunc(nullptr, xml_error_func);
+  installLibXmlHooks();
 
-  current_file = std::make_unique<UnicodeString>(source_file);
-  is_first_call = true;
+  XmlLoadContext load_ctx;
+  load_ctx.current_file = source_file;
 
-  // you can pass any string for the file name, it can be processed/converted into xml by MyExternalEntityLoader
-  xmldoc = xmlReadFile(UStr::to_stdstr(&source_file).c_str(), nullptr, XML_PARSE_NOENT | XML_PARSE_NONET);
+  xmlParserCtxtPtr ctxt = xmlNewParserCtxt();
+  if (ctxt == nullptr) {
+    return;
+  }
+  ctxt->_private = &load_ctx;
+  xmldoc = xmlCtxtReadFile(ctxt, UStr::to_stdstr(&source_file).c_str(), nullptr,
+                           XML_PARSE_NOENT | XML_PARSE_NONET);
+  ctxt->_private = nullptr;
+  xmlFreeParserCtxt(ctxt);
 }
 
 LibXmlReader::LibXmlReader(const XmlInputSource& source) : LibXmlReader(source.getPath()) {}
@@ -36,7 +92,12 @@ LibXmlReader::~LibXmlReader()
   if (xmldoc != nullptr) {
     xmlFreeDoc(xmldoc);
   }
-  current_file.reset();
+}
+
+void LibXmlReader::installLibXmlHooks()
+{
+  xmlSetExternalEntityLoader(xmlMyExternalEntityLoader);
+  xmlSetGenericErrorFunc(nullptr, xml_error_func);
 }
 
 void LibXmlReader::parse(std::list<XMLNode>& nodes)
@@ -116,8 +177,33 @@ void LibXmlReader::getAttributes(const xmlNode* node, std::unordered_map<Unicode
 #ifdef COLORER_FEATURE_ZIPINPUTSOURCE
 xmlParserInputPtr LibXmlReader::xmlZipEntityLoader(const PathInJar& paths, xmlParserCtxtPtr ctxt)
 {
-  const auto is = SharedXmlInputSource::getSharedInputSource(paths.path_to_jar);
-  is->open();
+  SharedXmlInputSource* is = nullptr;
+  std::unique_ptr<SharedXmlInputSource> owned;
+  auto* session_jars = XmlLoadSession::active();
+  if (session_jars != nullptr) {
+    auto& slot = session_jars->jars[paths.path_to_jar];
+    if (!slot) {
+      slot.reset(SharedXmlInputSource::getSharedInputSource(paths.path_to_jar));
+      slot->open();
+    }
+    is = slot.get();
+  }
+  else {
+    auto* ctx = loadContext(ctxt);
+    if (ctx != nullptr) {
+      auto& slot = ctx->jars[paths.path_to_jar];
+      if (!slot) {
+        slot.reset(SharedXmlInputSource::getSharedInputSource(paths.path_to_jar));
+        slot->open();
+      }
+      is = slot.get();
+    }
+    else {
+      owned.reset(SharedXmlInputSource::getSharedInputSource(paths.path_to_jar));
+      owned->open();
+      is = owned.get();
+    }
+  }
 
   const auto unzipped_stream = unzip(is->getSrc(), is->getSize(), paths.path_in_jar);
 
@@ -126,7 +212,6 @@ xmlParserInputPtr LibXmlReader::xmlZipEntityLoader(const PathInJar& paths, xmlPa
                                     static_cast<int>(unzipped_stream->size()), XML_CHAR_ENCODING_NONE);
   xmlParserInputPtr pInput = xmlNewIOInputStream(ctxt, buf, XML_CHAR_ENCODING_NONE);
 
-  // filling in the filename for the external entity to work
   const auto root_pos = paths.path_in_jar.lastIndexOf('/') + 1;
   const auto file_name = UnicodeString(paths.path_in_jar, root_pos);
   pInput->filename = strdup(UStr::to_stdstr(&file_name).c_str());
@@ -137,29 +222,32 @@ xmlParserInputPtr LibXmlReader::xmlZipEntityLoader(const PathInJar& paths, xmlPa
 xmlParserInputPtr LibXmlReader::xmlMyExternalEntityLoader(const char* URL, const char* /*ID*/, xmlParserCtxtPtr ctxt)
 {
   /*
-   * The function is called before each opening of a file within libxml, whether it is an xmlReadFile,
-   * or opening a file for an external entity.
-   * I.e., the path to the file can be checked or modified here. If the external entity specifies a path similar
-   * to the file path, then libxml itself forms the full path to the entity file by gluing the path from the current
-   * file and the one specified in the external entity. But sometimes it fails, for example, on non-Latin letters in
-   * the path to the main file.
-   * At the same time, there is no path to the source file or to the file in the entity in the function parameters.
+   * Called before each file open inside libxml (the main xmlCtxtReadFile
+   * and every external entity). Relative entity paths are resolved against
+   * the document being parsed — that path is stored on ctxt->_private so a
+   * second ParserFactory can load XML without clobbering another in-flight
+   * parse's current file.
    */
+  auto* ctx = loadContext(ctxt);
 
   auto filename = Encodings::fromUTF8(const_cast<char*>(URL), static_cast<int32_t>(strlen(URL)));
   UnicodeString string_url(*filename.get());
 
-  // read entity string like "env:$FAR_HOME/hrd/catalog-console.xml"
+  const bool first_call = ctx == nullptr || ctx->is_first_call;
+  const UnicodeString* current_file = ctx != nullptr ? &ctx->current_file : nullptr;
+
   static const UnicodeString env(u"env:");
-  if (!is_first_call && string_url.startsWith(env)) {
+  if (!first_call && string_url.startsWith(env)) {
     const auto exp = colorer::Environment::expandSpecialEnvironment(string_url);
     string_url = UnicodeString(exp, env.length());
   }
 
 #ifdef COLORER_FEATURE_ZIPINPUTSOURCE
-  if (string_url.startsWith(jar) || current_file->startsWith(jar)) {
-    const auto paths = LibXmlInputSource::getFullPathsToZip(string_url, is_first_call ? nullptr : current_file.get());
-    is_first_call = false;
+  if (string_url.startsWith(jar) || (current_file != nullptr && current_file->startsWith(jar))) {
+    const auto paths = LibXmlInputSource::getFullPathsToZip(string_url, first_call ? nullptr : current_file);
+    if (ctx != nullptr) {
+      ctx->is_first_call = false;
+    }
     xmlParserInputPtr ret = nullptr;
     try {
       ret = xmlZipEntityLoader(paths, ctxt);
@@ -168,17 +256,16 @@ xmlParserInputPtr LibXmlReader::xmlMyExternalEntityLoader(const char* URL, const
     return ret;
   }
 #endif
-  // We check if the file exists after all the conversions. If not, then we check the file relative to the one being processed.
-  // This is relevant for the case of non-Latin letters in the path to the main file and entity on linux. There is no such problem on windows.
-  if (!is_first_call && !colorer::Environment::isRegularFile(string_url)) {
-    auto new_string_url = colorer::Environment::getAbsolutePath(*current_file.get(), string_url);
+  if (!first_call && current_file != nullptr && !colorer::Environment::isRegularFile(string_url)) {
+    auto new_string_url = colorer::Environment::getAbsolutePath(*current_file, string_url);
     if (colorer::Environment::isRegularFile(new_string_url)) {
       string_url = std::move(new_string_url);
     }
   }
 
-  is_first_call = false;
-  // read it as a regular file
+  if (ctx != nullptr) {
+    ctx->is_first_call = false;
+  }
   xmlParserInputPtr ret = xmlNewInputFromFile(ctxt, UStr::to_stdstr(&string_url).c_str());
 
   return ret;
@@ -186,8 +273,8 @@ xmlParserInputPtr LibXmlReader::xmlMyExternalEntityLoader(const char* URL, const
 
 void LibXmlReader::xml_error_func(void* /*ctx*/, const char* msg, ...)
 {
-  static char buf[4096];
-  static int slen = 0;
+  thread_local char buf[4096];
+  thread_local int slen = 0;
   va_list args;
 
   /* libxml2 prints IO errors from bad includes paths by
@@ -199,7 +286,6 @@ void LibXmlReader::xml_error_func(void* /*ctx*/, const char* msg, ...)
   const int rc = vsnprintf(&buf[slen], sizeof(buf) - slen, msg, args);
   va_end(args);
 
-  /* This shouldn't really happen */
   if (rc < 0) {
     COLORER_LOG_ERROR("+++ out of cheese error. redo from start +++\n");
     slen = 0;
@@ -209,12 +295,10 @@ void LibXmlReader::xml_error_func(void* /*ctx*/, const char* msg, ...)
 
   slen += rc;
   if (slen >= static_cast<int>(sizeof(buf))) {
-    /* truncated, let's flush this */
     buf[sizeof(buf) - 1] = '\n';
     slen = sizeof(buf);
   }
 
-  /* We're assuming here that the last character is \n. */
   if (buf[slen - 1] == '\n') {
     buf[slen - 1] = '\0';
     COLORER_LOG_ERROR("%", buf);

--- a/src/colorer/xml/libxml2/LibXmlReader.h
+++ b/src/colorer/xml/libxml2/LibXmlReader.h
@@ -32,10 +32,8 @@ class LibXmlReader
   bool populateNode(xmlNode* node, XMLNode& result);
   static uUnicodeString getElementText(const xmlNode* node);
 
-  /* the name of the file that is being processed */
-  static uUnicodeString current_file;
-  /* is this the first xmlMyExternalEntityLoader call for current file*/
-  static bool is_first_call;
+  /* per-parse path/entity state lives on xmlParserCtxt::_private */
+  static void installLibXmlHooks();
   static xmlParserInputPtr xmlMyExternalEntityLoader(const char* URL, const char* ID, xmlParserCtxtPtr ctxt);
   static void xml_error_func(void* ctx, const char* msg, ...);
 

--- a/src/colorer/xml/libxml2/SharedXmlInputSource.cpp
+++ b/src/colorer/xml/libxml2/SharedXmlInputSource.cpp
@@ -3,8 +3,6 @@
 #include "colorer/Exception.h"
 #include "colorer/utils/Environment.h"
 
-std::unordered_map<UnicodeString, SharedXmlInputSource*>* SharedXmlInputSource::isHash = nullptr;
-
 int SharedXmlInputSource::addref()
 {
   return ++ref_count;
@@ -22,37 +20,12 @@ int SharedXmlInputSource::delref()
 
 SharedXmlInputSource* SharedXmlInputSource::getSharedInputSource(const UnicodeString& path)
 {
-  if (isHash == nullptr) {
-    isHash = new std::unordered_map<UnicodeString, SharedXmlInputSource*>();
-  }
-
-  const auto s = isHash->find(path);
-  if (s != isHash->end()) {
-    SharedXmlInputSource* sis = s->second;
-    sis->addref();
-    return sis;
-  }
-
-  auto* sis = new SharedXmlInputSource(path);
-  isHash->try_emplace(path, sis);
-  return sis;
+  return new SharedXmlInputSource(path);
 }
 
-SharedXmlInputSource::SharedXmlInputSource(const UnicodeString& path): source_path(path)
-{
+SharedXmlInputSource::SharedXmlInputSource(const UnicodeString& path) : source_path(path) {}
 
-  is_open = false;
-}
-
-SharedXmlInputSource::~SharedXmlInputSource()
-{
-  // You don't need to delete an object that has been deleted from the array. We are already in the destructor.
-  isHash->erase(source_path);
-  if (isHash->empty()) {
-    delete isHash;
-    isHash = nullptr;
-  }
-}
+SharedXmlInputSource::~SharedXmlInputSource() = default;
 
 int SharedXmlInputSource::getSize() const
 {

--- a/src/colorer/xml/libxml2/SharedXmlInputSource.h
+++ b/src/colorer/xml/libxml2/SharedXmlInputSource.h
@@ -1,9 +1,13 @@
 #ifndef SHAREDXMLINPUTSOURCE_H
 #define SHAREDXMLINPUTSOURCE_H
 
-#include <unordered_map>
 #include "colorer/Common.h"
 
+/** In-memory copy of a file (typically a zip catalog).
+ * Lifetime is owned by the caller via addref/delref — there is no
+ * process-wide cache, so a second ParserFactory can reload the same path
+ * and see current disk contents.
+ */
 class SharedXmlInputSource
 {
  public:
@@ -21,6 +25,8 @@ class SharedXmlInputSource
 
   void open();
 
+  ~SharedXmlInputSource();
+
   SharedXmlInputSource(SharedXmlInputSource const&) = delete;
   SharedXmlInputSource& operator=(SharedXmlInputSource const&) = delete;
   SharedXmlInputSource(SharedXmlInputSource&&) = delete;
@@ -28,9 +34,6 @@ class SharedXmlInputSource
 
  private:
   explicit SharedXmlInputSource(const UnicodeString& path);
-  ~SharedXmlInputSource();
-
-  static std::unordered_map<UnicodeString, SharedXmlInputSource*>* isHash;
 
   int ref_count {1};
   bool is_open {false};

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ set(unit_tests_SRC
     test_textparser.cpp
     test_lineregions.cpp
     test_baseeditor.cpp
+    test_parserfactory.cpp
     test_common.h
     TestLogger.h
     ${CMAKE_SOURCE_DIR}/external/catch2/catch_amalgamated.cpp

--- a/tests/unit/test_parserfactory.cpp
+++ b/tests/unit/test_parserfactory.cpp
@@ -1,0 +1,57 @@
+#include <catch2/catch_amalgamated.hpp>
+#include "colorer/HrcLibrary.h"
+#include "colorer/ParserFactory.h"
+#include "colorer/utils/FileSystems.h"
+#include "colorer/xml/XmlInputSource.h"
+
+TEST_CASE("A probe ParserFactory can load HRC without disturbing a live instance", "[parserfactory]")
+{
+  auto hrc_path = fs::path(__FILE__).parent_path() / "data" / "type_tryline.hrc";
+  UnicodeString location(hrc_path.c_str());
+
+  ParserFactory live;
+  live.loadHrcPath(&location);
+  auto* live_type = live.getHrcLibrary().getFileType(UnicodeString("try_line"));
+  REQUIRE(live_type != nullptr);
+  live.getHrcLibrary().loadFileType(live_type);
+  REQUIRE(live_type->getBaseScheme() != nullptr);
+
+  {
+    ParserFactory probe;
+    probe.loadHrcPath(&location);
+    auto* probe_type = probe.getHrcLibrary().getFileType(UnicodeString("try_line"));
+    REQUIRE(probe_type != nullptr);
+    probe.getHrcLibrary().loadFileType(probe_type);
+    REQUIRE(probe_type->getBaseScheme() != nullptr);
+    REQUIRE(probe_type != live_type);
+  }
+
+  REQUIRE(live.getHrcLibrary().getFileType(UnicodeString("try_line")) == live_type);
+  REQUIRE(live_type->getBaseScheme() != nullptr);
+}
+
+TEST_CASE("Two ParserFactory instances can parse the same catalog with entities", "[parserfactory]")
+{
+  auto catalog = fs::path(__FILE__).parent_path() / "data" / "catalog.xml";
+  UnicodeString path(catalog.c_str());
+
+  ParserFactory live;
+  live.loadCatalog(&path);
+
+  ParserFactory probe;
+  probe.loadCatalog(&path);
+}
+
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+TEST_CASE("Two ParserFactory instances can parse the same packed catalog", "[parserfactory]")
+{
+  auto catalog = fs::path(__FILE__).parent_path() / "data" / "catalog-allpacked.xml";
+  UnicodeString path(catalog.c_str());
+
+  ParserFactory live;
+  live.loadCatalog(&path);
+
+  ParserFactory probe;
+  probe.loadCatalog(&path);
+}
+#endif

--- a/tests/unit/test_xmlreader.cpp
+++ b/tests/unit/test_xmlreader.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_amalgamated.hpp>
+#include <list>
 #include "colorer/utils/Environment.h"
 #include "colorer/xml/XmlReader.h"
 #include "test_common.h"
@@ -74,3 +75,28 @@ TEST_CASE("Test read jar entity with env")
 }
 
 #endif
+
+TEST_CASE("Two XmlReaders can parse a catalog with entities one after another")
+{
+  logger->clean_messages();
+
+  UnicodeString path1(u"data/catalog.xml");
+  {
+    XmlInputSource is(path1);
+    XmlReader first(is);
+    REQUIRE(first.parse());
+    std::list<XMLNode> nodes;
+    first.getNodes(nodes);
+    REQUIRE_FALSE(nodes.empty());
+  }
+  {
+    XmlInputSource is(path1);
+    XmlReader second(is);
+    REQUIRE(second.parse());
+    std::list<XMLNode> nodes;
+    second.getNodes(nodes);
+    REQUIRE_FALSE(nodes.empty());
+  }
+
+  REQUIRE(logger->message_print() == false);
+}


### PR DESCRIPTION
Keep zip catalog bytes on the HrcLibrary instead of a process-wide map so a probe ParserFactory reloads current disk contents. Drop ParserFactory’s regex-stack reset and keep XML entity paths on the libxml parse context so the live instance is not disturbed.